### PR TITLE
Remove anonymous struct illegal in c++

### DIFF
--- a/include/glatter/platforms/glatter_egl_gles2_2_0/glatter_EGL_ges_decl.h
+++ b/include/glatter/platforms/glatter_egl_gles2_2_0/glatter_EGL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_EGL
+typedef struct glatter_extension_support_status_EGL
 {
-    int inexed_extensions[125];
-    struct {
         int has_EGL_ANDROID_blob_cache;
         int has_EGL_ANDROID_create_native_client_buffer;
         int has_EGL_ANDROID_framebuffer_target;
@@ -162,7 +160,6 @@ typedef union glatter_extension_support_status_union_EGL
         int has_EGL_NV_system_time;
         int has_EGL_TIZEN_image_native_buffer;
         int has_EGL_TIZEN_image_native_surface;
-    };
 } glatter_extension_support_status_EGL_t;
 
 

--- a/include/glatter/platforms/glatter_egl_gles2_2_0/glatter_EGL_ges_def.h
+++ b/include/glatter/platforms/glatter_egl_gles2_2_0/glatter_EGL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
 {
+    static int indexed_extensions[125];
     static glatter_extension_support_status_EGL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -731,7 +734,7 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -754,7 +757,7 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
             for ( ; r && (r->hash | r->index); r++ ) {
                 if (r->hash == hash) {
                     index = r->index;
-                    ess.inexed_extensions[index] = 1;
+                    indexed_extensions[index] = 1;
                     break;
                 }
             }
@@ -764,6 +767,10 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
         }
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_egl_gles2_2_0/glatter_GL_ges_decl.h
+++ b/include/glatter/platforms/glatter_egl_gles2_2_0/glatter_GL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_GL
+typedef struct glatter_extension_support_status_GL
 {
-    int inexed_extensions[276];
-    struct {
         int has_GL_AMD_compressed_3DC_texture;
         int has_GL_AMD_compressed_ATC_texture;
         int has_GL_AMD_framebuffer_multisample_advanced;
@@ -313,7 +311,6 @@ typedef union glatter_extension_support_status_union_GL
         int has_GL_QCOM_tiled_rendering;
         int has_GL_QCOM_writeonly_rendering;
         int has_GL_VIV_shader_binary;
-    };
 } glatter_extension_support_status_GL_t;
 
 

--- a/include/glatter/platforms/glatter_egl_gles2_2_0/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_egl_gles2_2_0/glatter_GL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 {
+    static int indexed_extensions[276];
     static glatter_extension_support_status_GL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -887,7 +890,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -911,7 +914,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                     for ( ; r && (r->hash | r->index); r++ ) {
                         if (r->hash == hash) {
                             index = r->index;
-                            ess.inexed_extensions[index] = 1;
+                            indexed_extensions[index] = 1;
                             break;
                         }
                     }
@@ -934,7 +937,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -948,6 +951,10 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_egl_gles_1_1/glatter_EGL_ges_decl.h
+++ b/include/glatter/platforms/glatter_egl_gles_1_1/glatter_EGL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_EGL
+typedef struct glatter_extension_support_status_EGL
 {
-    int inexed_extensions[125];
-    struct {
         int has_EGL_ANDROID_blob_cache;
         int has_EGL_ANDROID_create_native_client_buffer;
         int has_EGL_ANDROID_framebuffer_target;
@@ -162,7 +160,6 @@ typedef union glatter_extension_support_status_union_EGL
         int has_EGL_NV_system_time;
         int has_EGL_TIZEN_image_native_buffer;
         int has_EGL_TIZEN_image_native_surface;
-    };
 } glatter_extension_support_status_EGL_t;
 
 

--- a/include/glatter/platforms/glatter_egl_gles_1_1/glatter_EGL_ges_def.h
+++ b/include/glatter/platforms/glatter_egl_gles_1_1/glatter_EGL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
 {
+    static int indexed_extensions[125];
     static glatter_extension_support_status_EGL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -731,7 +734,7 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -754,7 +757,7 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
             for ( ; r && (r->hash | r->index); r++ ) {
                 if (r->hash == hash) {
                     index = r->index;
-                    ess.inexed_extensions[index] = 1;
+                    indexed_extensions[index] = 1;
                     break;
                 }
             }
@@ -764,6 +767,10 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
         }
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_egl_gles_1_1/glatter_GL_ges_decl.h
+++ b/include/glatter/platforms/glatter_egl_gles_1_1/glatter_GL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_GL
+typedef struct glatter_extension_support_status_GL
 {
-    int inexed_extensions[74];
-    struct {
         int has_GL_AMD_compressed_3DC_texture;
         int has_GL_AMD_compressed_ATC_texture;
         int has_GL_APPLE_copy_texture_levels;
@@ -111,7 +109,6 @@ typedef union glatter_extension_support_status_union_GL
         int has_GL_QCOM_perfmon_global_mode;
         int has_GL_QCOM_tiled_rendering;
         int has_GL_QCOM_writeonly_rendering;
-    };
 } glatter_extension_support_status_GL_t;
 
 

--- a/include/glatter/platforms/glatter_egl_gles_1_1/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_egl_gles_1_1/glatter_GL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 {
+    static int indexed_extensions[74];
     static glatter_extension_support_status_GL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -689,7 +692,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -713,7 +716,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                     for ( ; r && (r->hash | r->index); r++ ) {
                         if (r->hash == hash) {
                             index = r->index;
-                            ess.inexed_extensions[index] = 1;
+                            indexed_extensions[index] = 1;
                             break;
                         }
                     }
@@ -736,7 +739,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -750,6 +753,10 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_egl_gles_3_0/glatter_EGL_ges_decl.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_0/glatter_EGL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_EGL
+typedef struct glatter_extension_support_status_EGL
 {
-    int inexed_extensions[125];
-    struct {
         int has_EGL_ANDROID_blob_cache;
         int has_EGL_ANDROID_create_native_client_buffer;
         int has_EGL_ANDROID_framebuffer_target;
@@ -162,7 +160,6 @@ typedef union glatter_extension_support_status_union_EGL
         int has_EGL_NV_system_time;
         int has_EGL_TIZEN_image_native_buffer;
         int has_EGL_TIZEN_image_native_surface;
-    };
 } glatter_extension_support_status_EGL_t;
 
 

--- a/include/glatter/platforms/glatter_egl_gles_3_0/glatter_EGL_ges_def.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_0/glatter_EGL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
 {
+    static int indexed_extensions[125];
     static glatter_extension_support_status_EGL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -731,7 +734,7 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -754,7 +757,7 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
             for ( ; r && (r->hash | r->index); r++ ) {
                 if (r->hash == hash) {
                     index = r->index;
-                    ess.inexed_extensions[index] = 1;
+                    indexed_extensions[index] = 1;
                     break;
                 }
             }
@@ -764,6 +767,10 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
         }
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_egl_gles_3_0/glatter_GL_ges_decl.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_0/glatter_GL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_GL
+typedef struct glatter_extension_support_status_GL
 {
-    int inexed_extensions[276];
-    struct {
         int has_GL_AMD_compressed_3DC_texture;
         int has_GL_AMD_compressed_ATC_texture;
         int has_GL_AMD_framebuffer_multisample_advanced;
@@ -313,7 +311,6 @@ typedef union glatter_extension_support_status_union_GL
         int has_GL_QCOM_tiled_rendering;
         int has_GL_QCOM_writeonly_rendering;
         int has_GL_VIV_shader_binary;
-    };
 } glatter_extension_support_status_GL_t;
 
 

--- a/include/glatter/platforms/glatter_egl_gles_3_0/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_0/glatter_GL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 {
+    static int indexed_extensions[276];
     static glatter_extension_support_status_GL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -887,7 +890,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -911,7 +914,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                     for ( ; r && (r->hash | r->index); r++ ) {
                         if (r->hash == hash) {
                             index = r->index;
-                            ess.inexed_extensions[index] = 1;
+                            indexed_extensions[index] = 1;
                             break;
                         }
                     }
@@ -934,7 +937,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -948,6 +951,10 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_egl_gles_3_1/glatter_EGL_ges_decl.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_1/glatter_EGL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_EGL
+typedef struct glatter_extension_support_status_EGL
 {
-    int inexed_extensions[125];
-    struct {
         int has_EGL_ANDROID_blob_cache;
         int has_EGL_ANDROID_create_native_client_buffer;
         int has_EGL_ANDROID_framebuffer_target;
@@ -162,7 +160,6 @@ typedef union glatter_extension_support_status_union_EGL
         int has_EGL_NV_system_time;
         int has_EGL_TIZEN_image_native_buffer;
         int has_EGL_TIZEN_image_native_surface;
-    };
 } glatter_extension_support_status_EGL_t;
 
 

--- a/include/glatter/platforms/glatter_egl_gles_3_1/glatter_EGL_ges_def.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_1/glatter_EGL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
 {
+    static int indexed_extensions[125];
     static glatter_extension_support_status_EGL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -731,7 +734,7 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -754,7 +757,7 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
             for ( ; r && (r->hash | r->index); r++ ) {
                 if (r->hash == hash) {
                     index = r->index;
-                    ess.inexed_extensions[index] = 1;
+                    indexed_extensions[index] = 1;
                     break;
                 }
             }
@@ -764,6 +767,10 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
         }
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_egl_gles_3_1/glatter_GL_ges_decl.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_1/glatter_GL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_GL
+typedef struct glatter_extension_support_status_GL
 {
-    int inexed_extensions[276];
-    struct {
         int has_GL_AMD_compressed_3DC_texture;
         int has_GL_AMD_compressed_ATC_texture;
         int has_GL_AMD_framebuffer_multisample_advanced;
@@ -313,7 +311,6 @@ typedef union glatter_extension_support_status_union_GL
         int has_GL_QCOM_tiled_rendering;
         int has_GL_QCOM_writeonly_rendering;
         int has_GL_VIV_shader_binary;
-    };
 } glatter_extension_support_status_GL_t;
 
 

--- a/include/glatter/platforms/glatter_egl_gles_3_1/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_1/glatter_GL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 {
+    static int indexed_extensions[276];
     static glatter_extension_support_status_GL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -887,7 +890,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -911,7 +914,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                     for ( ; r && (r->hash | r->index); r++ ) {
                         if (r->hash == hash) {
                             index = r->index;
-                            ess.inexed_extensions[index] = 1;
+                            indexed_extensions[index] = 1;
                             break;
                         }
                     }
@@ -934,7 +937,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -948,6 +951,10 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_egl_gles_3_2/glatter_GL_ges_decl.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_2/glatter_GL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_GL
+typedef struct glatter_extension_support_status_GL
 {
-    int inexed_extensions[276];
-    struct {
         int has_GL_AMD_compressed_3DC_texture;
         int has_GL_AMD_compressed_ATC_texture;
         int has_GL_AMD_framebuffer_multisample_advanced;
@@ -313,7 +311,6 @@ typedef union glatter_extension_support_status_union_GL
         int has_GL_QCOM_tiled_rendering;
         int has_GL_QCOM_writeonly_rendering;
         int has_GL_VIV_shader_binary;
-    };
 } glatter_extension_support_status_GL_t;
 
 

--- a/include/glatter/platforms/glatter_egl_gles_3_2/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_egl_gles_3_2/glatter_GL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 {
+    static int indexed_extensions[276];
     static glatter_extension_support_status_GL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -887,7 +890,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -911,7 +914,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                     for ( ; r && (r->hash | r->index); r++ ) {
                         if (r->hash == hash) {
                             index = r->index;
-                            ess.inexed_extensions[index] = 1;
+                            indexed_extensions[index] = 1;
                             break;
                         }
                     }
@@ -934,7 +937,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -948,6 +951,10 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GLX_ges_decl.h
+++ b/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GLX_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_GLX
+typedef struct glatter_extension_support_status_GLX
 {
-    int inexed_extensions[67];
-    struct {
         int has_GLX_3DFX_multisample;
         int has_GLX_AMD_gpu_association;
         int has_GLX_ARB_context_flush_control;
@@ -104,7 +102,6 @@ typedef union glatter_extension_support_status_union_GLX
         int has_GLX_SGI_swap_control;
         int has_GLX_SGI_video_sync;
         int has_GLX_SUN_get_transparent_index;
-    };
 } glatter_extension_support_status_GLX_t;
 
 

--- a/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GLX_ges_def.h
+++ b/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GLX_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
 {
+    static int indexed_extensions[67];
     static glatter_extension_support_status_GLX_t ess;
 
     typedef glatter_es_record_t rt;
@@ -674,7 +677,7 @@ glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -697,7 +700,7 @@ glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
             for ( ; r && (r->hash | r->index); r++ ) {
                 if (r->hash == hash) {
                     index = r->index;
-                    ess.inexed_extensions[index] = 1;
+                    indexed_extensions[index] = 1;
                     break;
                 }
             }
@@ -707,6 +710,10 @@ glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
         }
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_decl.h
+++ b/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_GL
+typedef struct glatter_extension_support_status_GL
 {
-    int inexed_extensions[591];
-    struct {
         int has_GL_3DFX_multisample;
         int has_GL_3DFX_tbuffer;
         int has_GL_3DFX_texture_compression_FXT1;
@@ -628,7 +626,6 @@ typedef union glatter_extension_support_status_union_GL
         int has_GL_SUN_vertex;
         int has_GL_WIN_phong_shading;
         int has_GL_WIN_specular_fog;
-    };
 } glatter_extension_support_status_GL_t;
 
 

--- a/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 {
+    static int indexed_extensions[591];
     static glatter_extension_support_status_GL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -1196,7 +1199,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -1220,7 +1223,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                     for ( ; r && (r->hash | r->index); r++ ) {
                         if (r->hash == hash) {
                             index = r->index;
-                            ess.inexed_extensions[index] = 1;
+                            indexed_extensions[index] = 1;
                             break;
                         }
                     }
@@ -1243,7 +1246,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -1257,6 +1260,10 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_decl.h
+++ b/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_GL
+typedef struct glatter_extension_support_status_GL
 {
-    int inexed_extensions[589];
-    struct {
         int has_GL_3DFX_multisample;
         int has_GL_3DFX_tbuffer;
         int has_GL_3DFX_texture_compression_FXT1;
@@ -626,7 +624,6 @@ typedef union glatter_extension_support_status_union_GL
         int has_GL_SUN_vertex;
         int has_GL_WIN_phong_shading;
         int has_GL_WIN_specular_fog;
-    };
 } glatter_extension_support_status_GL_t;
 
 

--- a/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 {
+    static int indexed_extensions[589];
     static glatter_extension_support_status_GL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -1194,7 +1197,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -1218,7 +1221,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                     for ( ; r && (r->hash | r->index); r++ ) {
                         if (r->hash == hash) {
                             index = r->index;
-                            ess.inexed_extensions[index] = 1;
+                            indexed_extensions[index] = 1;
                             break;
                         }
                     }
@@ -1241,7 +1244,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -1255,6 +1258,10 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_windows_wgl_gl/glatter_WGL_ges_decl.h
+++ b/include/glatter/platforms/glatter_windows_wgl_gl/glatter_WGL_ges_decl.h
@@ -33,10 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma warning(disable : 4201)
 #endif
 
-typedef union glatter_extension_support_status_union_WGL
+typedef struct glatter_extension_support_status_WGL
 {
-    int inexed_extensions[55];
-    struct {
         int has_WGL_3DFX_multisample;
         int has_WGL_3DL_stereo_control;
         int has_WGL_AMD_gpu_association;
@@ -92,7 +90,6 @@ typedef union glatter_extension_support_status_union_WGL
         int has_WGL_NV_video_capture;
         int has_WGL_NV_video_output;
         int has_WGL_OML_sync_control;
-    };
 } glatter_extension_support_status_WGL_t;
 
 

--- a/include/glatter/platforms/glatter_windows_wgl_gl/glatter_WGL_ges_def.h
+++ b/include/glatter/platforms/glatter_windows_wgl_gl/glatter_WGL_ges_def.h
@@ -27,9 +27,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+#include <string.h> /* memcpy */
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_WGL_t glatter_get_extension_support_WGL()
 {
+    static int indexed_extensions[55];
     static glatter_extension_support_status_WGL_t ess;
 
     typedef glatter_es_record_t rt;
@@ -661,7 +664,7 @@ glatter_extension_support_status_WGL_t glatter_get_extension_support_WGL()
                 for ( ; r && (r->hash | r->index); r++ ) {
                     if (r->hash == hash) {
                         index = r->index;
-                        ess.inexed_extensions[index] = 1;
+                        indexed_extensions[index] = 1;
                         break;
                     }
                 }
@@ -684,7 +687,7 @@ glatter_extension_support_status_WGL_t glatter_get_extension_support_WGL()
             for ( ; r && (r->hash | r->index); r++ ) {
                 if (r->hash == hash) {
                     index = r->index;
-                    ess.inexed_extensions[index] = 1;
+                    indexed_extensions[index] = 1;
                     break;
                 }
             }
@@ -694,6 +697,10 @@ glatter_extension_support_status_WGL_t glatter_get_extension_support_WGL()
         }
         initialized = 1;
     }
+    
+    // Map array to a struct without undefined behaviour.
+    // No actual copy is performed with even basic optimization e.g.: -Og
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
 
     return ess;
 }


### PR DESCRIPTION
These changes remove union mapping - which is undefined behaviour due to layout uncertainty.
Anonymous struct which is inside union generates lots of warnings.
Tested under Linux mesa.