### PR TITLE
Handle NULL inputs in glatter_log

### DIFF
--- a/include/glatter/glatter_def.h
+++ b/include/glatter/glatter_def.h
@@ -84,7 +84,12 @@ void (*glatter_log_handler())(const char*)
 GLATTER_INLINE_OR_NOT
 const char* glatter_log(const char* str)
 {
-    (*(glatter_log_handler_ptr_ptr()))(str);
+    const char* message = str;
+    if (message == NULL) {
+        static const char fallback[] = "GLATTER: message formatting failed.\n";
+        message = fallback;
+    }
+    (*(glatter_log_handler_ptr_ptr()))(message);
     return str;
 }
 

--- a/tests/test_glatter_log_null.c
+++ b/tests/test_glatter_log_null.c
@@ -1,0 +1,59 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define GLATTER_CONFIG_H_DEFINED
+/*
+ * Provide a minimal configuration for the test. We skip the default
+ * configuration header so we can compile without depending on any
+ * platform-specific GL/EGL headers that may not be available.
+ */
+
+char* glatter_masprintf(const char* format, ...);
+
+#define GLATTER_MASPRINTF_H
+#include <glatter/glatter_def.h>
+
+static const char* g_last_log_message = NULL;
+
+static void test_log_handler(const char* str)
+{
+    g_last_log_message = str;
+}
+
+char* glatter_masprintf(const char* format, ...)
+{
+    (void)format;
+    return NULL;
+}
+
+int main(void)
+{
+    glatter_set_log_handler(test_log_handler);
+
+    const char* formatted = glatter_masprintf("glatter should fall back");
+    const char* logged = glatter_log(formatted);
+
+    if (formatted != NULL) {
+        fprintf(stderr, "expected glatter_masprintf to fail\n");
+        return 1;
+    }
+
+    if (logged != NULL) {
+        fprintf(stderr, "glatter_log should return NULL when input is NULL\n");
+        return 1;
+    }
+
+    if (g_last_log_message == NULL) {
+        fprintf(stderr, "log handler was not invoked\n");
+        return 1;
+    }
+
+    if (strcmp(g_last_log_message, "GLATTER: message formatting failed.\n") != 0) {
+        fprintf(stderr, "unexpected fallback message: %s\n", g_last_log_message);
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- make glatter_log substitute a fallback message when passed NULL so that the handler never dereferences a null pointer
- add a regression test that simulates a glatter_masprintf allocation failure and verifies the fallback path

## Testing
- `gcc -Iinclude tests/test_glatter_log_null.c -o tests/test_glatter_log_null`
- `./tests/test_glatter_log_null`


------
https://chatgpt.com/codex/tasks/task_b_68d6adae071c832db2560eb74b306290