### PR TITLE
Ensure NULL log handler resets to default

### DIFF
--- a/include/glatter/glatter_def.h
+++ b/include/glatter/glatter_def.h
@@ -97,6 +97,9 @@ const char* glatter_log(const char* str)
 GLATTER_INLINE_OR_NOT
 void glatter_set_log_handler(void(*handler_ptr)(const char*))
 {
+    if (handler_ptr == NULL) {
+        handler_ptr = glatter_default_log_handler;
+    }
     *(glatter_log_handler_ptr_ptr()) = handler_ptr;
 }
 

--- a/tests/test_glatter_log_null.c
+++ b/tests/test_glatter_log_null.c
@@ -55,5 +55,15 @@ int main(void)
         return 1;
     }
 
+    glatter_set_log_handler(NULL);
+
+    if (glatter_log_handler() != glatter_default_log_handler) {
+        fprintf(stderr, "NULL handler did not reset to default handler\n");
+        return 1;
+    }
+
+    /* Smoke test to ensure the default handler can be invoked safely. */
+    glatter_log("GLATTER: default handler smoke test.\n");
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- ensure `glatter_set_log_handler` substitutes the default handler when passed `NULL`
- extend the existing log handler test to verify the default handler is restored and can be invoked safely

## Testing
- cc -Iinclude tests/test_glatter_log_null.c -o tests/test_glatter_log_null
- ./tests/test_glatter_log_null


------
https://chatgpt.com/codex/tasks/task_b_68d6b9b3bfe8832db64b2eb700482cd5