### PR TITLE
Fix Windows header include casing

### DIFF
--- a/include/glatter/glatter_platform_headers.h
+++ b/include/glatter/glatter_platform_headers.h
@@ -30,7 +30,7 @@
     #ifndef WIN32_LEAN_AND_MEAN
     #define WIN32_LEAN_AND_MEAN
     #endif
-    #include <Windows.h>
+    #include <windows.h>
 #elif defined (__linux__)
     #include <pthread.h>
     #include <dlfcn.h>


### PR DESCRIPTION
## Summary
- adjust the Windows platform include to use the lowercase windows.h name
- ensure the header resolves correctly on case-sensitive toolchains

## Testing
- not run (Windows-specific builds not available in this environment)

------
https://chatgpt.com/codex/tasks/task_b_68d6c702fae0832dafe645281ce7fb9f