### PR TITLE
Handle versioned GLES/EGL libraries on Linux

### DIFF
--- a/tests/test_linux_versioned_loader.cpp
+++ b/tests/test_linux_versioned_loader.cpp
@@ -1,0 +1,36 @@
+#include <cstdio>
+#include <cstdlib>
+
+#define GLATTER_EGL_GLES_3_0
+#define GLATTER_GL
+#define GLATTER_EGL
+
+#include "glatter/glatter.h"
+
+#undef eglGetProcAddress
+
+extern "C" __eglMustCastToProperFunctionPointerType eglGetProcAddress(const char*)
+{
+    return NULL;
+}
+
+int main()
+{
+    void* symbol = glatter_get_proc_address("glGetString");
+    if (symbol == NULL) {
+        std::fprintf(stderr, "glGetString not found\n");
+        return EXIT_FAILURE;
+    }
+
+    typedef const unsigned char* (*glGetString_t)(unsigned int);
+    glGetString_t glGetString_ptr = reinterpret_cast<glGetString_t>(symbol);
+    const unsigned char* value = glGetString_ptr(0);
+
+    if (value == NULL) {
+        std::fprintf(stderr, "glGetString returned NULL\n");
+        return EXIT_FAILURE;
+    }
+
+    std::puts(reinterpret_cast<const char*>(value));
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- iterate over common EGL and GLES sonames on Linux, caching successful dlopen handles for reuse
- add a small test program that loads a GLES core symbol through glatter_get_proc_address

## Testing
- LD_LIBRARY_PATH=/tmp/glatter-libs /tmp/test_linux_versioned_loader

------
https://chatgpt.com/codex/tasks/task_b_68d6c6c23378832db2f8dc5a3098a4c6