### PR TITLE
Avoid heap allocations in logging path

### DIFF
--- a/tests/test_glatter_log_null.c
+++ b/tests/test_glatter_log_null.c
@@ -1,25 +1,53 @@
+#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#define GLATTER_CONFIG_H_DEFINED
 /*
  * Provide a minimal configuration for the test. We skip the default
  * configuration header so we can compile without depending on any
  * platform-specific GL/EGL headers that may not be available.
  */
+#define GLATTER_CONFIG_H_DEFINED
 
+/*
+ * Pretend the platform headers are already provided and supply the enum
+ * aliases glatter_def.h expects. This keeps the test focused on the logging
+ * helpers without pulling real GL headers.
+ */
+#define GLATTER_PLATFORM_HEADERS_H_DEFINED
+typedef unsigned int GLATTER_ENUM_GL;
+typedef unsigned int GLATTER_ENUM_GLX;
+typedef unsigned int GLATTER_ENUM_WGL;
+typedef unsigned int GLATTER_ENUM_GLU;
+typedef int          GLATTER_ENUM_EGL;
 char* glatter_masprintf(const char* format, ...);
 
 #define GLATTER_MASPRINTF_H
 #include <glatter/glatter_def.h>
 
+pthread_once_t glatter_thread_once = PTHREAD_ONCE_INIT;
+pthread_t      glatter_thread_id;
+
+static char        g_last_log_buffer[1024];
 static const char* g_last_log_message = NULL;
 
 static void test_log_handler(const char* str)
 {
-    g_last_log_message = str;
+    if (str == NULL) {
+        g_last_log_message = NULL;
+        return;
+    }
+
+    size_t len = strlen(str);
+    if (len >= sizeof(g_last_log_buffer)) {
+        len = sizeof(g_last_log_buffer) - 1;
+    }
+
+    memcpy(g_last_log_buffer, str, len);
+    g_last_log_buffer[len] = '\0';
+    g_last_log_message = g_last_log_buffer;
 }
 
 char* glatter_masprintf(const char* format, ...)
@@ -64,6 +92,14 @@ int main(void)
 
     /* Smoke test to ensure the default handler can be invoked safely. */
     glatter_log("GLATTER: default handler smoke test.\n");
+
+    glatter_set_log_handler(test_log_handler);
+    glatter_log_printf("GLATTER: printf test %d\n", 42);
+
+    if (strcmp(g_last_log_message, "GLATTER: printf test 42\n") != 0) {
+        fprintf(stderr, "unexpected printf log message: %s\n", g_last_log_message);
+        return 1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a stack-backed `glatter_log_printf` helper for logging
- switch debug call/error logging to use the new formatter instead of heap allocations
- update the logging test to copy handler strings and cover `glatter_log_printf`

## Testing
- cc -Iinclude tests/test_glatter_log_null.c -pthread -o /tmp/test_glatter_log_null
- /tmp/test_glatter_log_null


------
https://chatgpt.com/codex/tasks/task_b_68d777a80d50832da4d82d330860c7a6