### PR TITLE
Simplify NULL guarding in extension parsing

### DIFF
--- a/include/glatter/glatter.py
+++ b/include/glatter/glatter.py
@@ -1043,7 +1043,7 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
 #endif
             uint32_t hash = 5381;
             const uint8_t* ext_str = (const uint8_t*)glatter_glGetString(GL_EXTENSIONS);
-            for ( ; *ext_str; ext_str++) {
+            for ( ; ext_str && *ext_str; ext_str++) {
                 if (*ext_str == ' ') {
                     int index = -1;
                     rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
@@ -1067,7 +1067,7 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
                 hash = ((hash << 5) + hash) + (int)(*ext_str);
 
             }
-            if (hash != 5381) {
+            if (ext_str && hash != 5381) {
                 int index = -1;
                 rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
                 for ( ; r && (r->hash | r->index); r++ ) {
@@ -1089,7 +1089,7 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
         if (v == 'GLX'):
             estring_acquisition = '''
         Display* d = glXGetCurrentDisplay();
-        const uint8_t* ext_str = (const uint8_t*)glatter_glXQueryExtensionsString(d, DefaultScreen(d));'''
+        const uint8_t* ext_str = d ? (const uint8_t*)glatter_glXQueryExtensionsString(d, DefaultScreen(d)) : NULL;'''
         elif (v == 'WGL'):
             estring_acquisition = '''
         const uint8_t* ext_str = (const uint8_t*)glatter_wglGetExtensionsStringEXT();'''
@@ -1099,7 +1099,7 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
 
         rv += '''
         uint32_t hash = 5381;''' + estring_acquisition + '''
-        for ( ; *ext_str; ext_str++) {
+        for ( ; ext_str && *ext_str; ext_str++) {
             if (*ext_str == ' ') {
                 int index = -1;
                 rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
@@ -1123,7 +1123,7 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
             hash = ((hash << 5) + hash) + (int)(*ext_str);
 
         }
-        if (hash != 5381) {
+        if (ext_str && hash != 5381) {
             int index = -1;
             rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
             for ( ; r && (r->hash | r->index); r++ ) {
@@ -1136,7 +1136,8 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
             if (index == -1) {
                 // (3)
             }
-        }'''
+        }
+        '''
 
     rv += '''
         initialized = 1;

--- a/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GLX_ges_def.h
+++ b/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GLX_ges_def.h
@@ -670,8 +670,8 @@ glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
 
         uint32_t hash = 5381;
         Display* d = glXGetCurrentDisplay();
-        const uint8_t* ext_str = (const uint8_t*)glatter_glXQueryExtensionsString(d, DefaultScreen(d));
-        for ( ; *ext_str; ext_str++) {
+        const uint8_t* ext_str = d ? (const uint8_t*)glatter_glXQueryExtensionsString(d, DefaultScreen(d)) : NULL;
+        for ( ; ext_str && *ext_str; ext_str++) {
             if (*ext_str == ' ') {
                 int index = -1;
                 rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
@@ -695,7 +695,7 @@ glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
             hash = ((hash << 5) + hash) + (int)(*ext_str);
 
         }
-        if (hash != 5381) {
+        if (ext_str && hash != 5381) {
             int index = -1;
             rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
             for ( ; r && (r->hash | r->index); r++ ) {
@@ -709,6 +709,7 @@ glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
                 // (3)
             }
         }
+        
         initialized = 1;
     }
     

--- a/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_def.h
@@ -1243,7 +1243,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 #endif
             uint32_t hash = 5381;
             const uint8_t* ext_str = (const uint8_t*)glatter_glGetString(GL_EXTENSIONS);
-            for ( ; *ext_str; ext_str++) {
+            for ( ; ext_str && *ext_str; ext_str++) {
                 if (*ext_str == ' ') {
                     int index = -1;
                     rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
@@ -1267,7 +1267,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 hash = ((hash << 5) + hash) + (int)(*ext_str);
 
             }
-            if (hash != 5381) {
+            if (ext_str && hash != 5381) {
                 int index = -1;
                 rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
                 for ( ; r && (r->hash | r->index); r++ ) {

--- a/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_def.h
@@ -1243,7 +1243,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 #endif
             uint32_t hash = 5381;
             const uint8_t* ext_str = (const uint8_t*)glatter_glGetString(GL_EXTENSIONS);
-            for ( ; *ext_str; ext_str++) {
+            for ( ; ext_str && *ext_str; ext_str++) {
                 if (*ext_str == ' ') {
                     int index = -1;
                     rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
@@ -1267,7 +1267,7 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
                 hash = ((hash << 5) + hash) + (int)(*ext_str);
 
             }
-            if (hash != 5381) {
+            if (ext_str && hash != 5381) {
                 int index = -1;
                 rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
                 for ( ; r && (r->hash | r->index); r++ ) {

--- a/include/glatter/platforms/glatter_windows_wgl_gl/glatter_WGL_ges_def.h
+++ b/include/glatter/platforms/glatter_windows_wgl_gl/glatter_WGL_ges_def.h
@@ -658,7 +658,7 @@ glatter_extension_support_status_WGL_t glatter_get_extension_support_WGL()
 
         uint32_t hash = 5381;
         const uint8_t* ext_str = (const uint8_t*)glatter_wglGetExtensionsStringEXT();
-        for ( ; *ext_str; ext_str++) {
+        for ( ; ext_str && *ext_str; ext_str++) {
             if (*ext_str == ' ') {
                 int index = -1;
                 rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
@@ -682,7 +682,7 @@ glatter_extension_support_status_WGL_t glatter_get_extension_support_WGL()
             hash = ((hash << 5) + hash) + (int)(*ext_str);
 
         }
-        if (hash != 5381) {
+        if (ext_str && hash != 5381) {
             int index = -1;
             rt* r = es_dispatch[ hash & (GLATTER_LOOKUP_SIZE-1) ];
             for ( ; r && (r->hash | r->index); r++ ) {
@@ -696,6 +696,7 @@ glatter_extension_support_status_WGL_t glatter_get_extension_support_WGL()
                 // (3)
             }
         }
+        
         initialized = 1;
     }
     


### PR DESCRIPTION
## Summary
- inline the NULL checks directly into the extension parsing loops emitted by the generator to keep the generated code small
- avoid calling DefaultScreen when there is no current GLX display by using a conditional expression
- regenerate the GL, GLX, and WGL extension support headers with the compact NULL-guarded loops

## Testing
- (cd include/glatter && python glatter.py)
- pytest *(fails: requires GLES platform configuration headers)*

------
https://chatgpt.com/codex/tasks/task_b_68d777f941e0832d96774031af95c916