### PR TITLE
Add fallback for EGL builds without generated headers

### DIFF
--- a/include/glatter/glatter.h
+++ b/include/glatter/glatter.h
@@ -60,7 +60,9 @@ extern "C" {
 #endif
 
 #if defined(GLATTER_EGL)
-	#include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_ges_decl.h)
+#if GLATTER_HAS_EGL_GENERATED_HEADERS
+        #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_ges_decl.h)
+#endif
 #endif
 
 #if defined(GLATTER_WGL)
@@ -132,7 +134,7 @@ void glatter_set_log_handler(void(*handler_ptr)(const char*));
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_d.h)
     #endif
 
-    #if defined(GLATTER_EGL)
+    #if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_d.h)
     #endif
 
@@ -154,7 +156,7 @@ void glatter_set_log_handler(void(*handler_ptr)(const char*));
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_r.h)
     #endif
 
-    #if defined(GLATTER_EGL)
+    #if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_r.h)
     #endif
 

--- a/include/glatter/glatter_def.h
+++ b/include/glatter/glatter_def.h
@@ -782,7 +782,7 @@ typedef struct glatter_es_record_struct
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_d_def.h)
     #endif
 
-    #if defined(GLATTER_EGL)
+    #if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_d_def.h)
     #endif
 
@@ -804,7 +804,7 @@ typedef struct glatter_es_record_struct
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_r_def.h)
     #endif
 
-    #if defined(GLATTER_EGL)
+    #if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_r_def.h)
     #endif
 
@@ -830,7 +830,7 @@ typedef struct glatter_es_record_struct
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_ges_decl.h)
 #endif
 
-#if defined(GLATTER_EGL)
+#if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_ges_decl.h)
 #endif
 
@@ -850,7 +850,7 @@ typedef struct glatter_es_record_struct
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_ges_def.h)
 #endif
 
-#if defined(GLATTER_EGL)
+#if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_ges_def.h)
 #endif
 
@@ -868,7 +868,7 @@ typedef struct glatter_es_record_struct
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_e2s_def.h)
 #endif
 
-#if defined(GLATTER_EGL)
+#if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_e2s_def.h)
 #endif
 
@@ -878,6 +878,22 @@ typedef struct glatter_es_record_struct
 
 #if defined(GLATTER_GLU)
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLU_e2s_def.h)
+#endif
+
+#if defined(GLATTER_EGL) && !GLATTER_HAS_EGL_GENERATED_HEADERS
+
+GLATTER_INLINE_OR_NOT glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL(void)
+{
+    glatter_extension_support_status_EGL_t status = {0};
+    return status;
+}
+
+GLATTER_INLINE_OR_NOT const char* enum_to_string_EGL(GLATTER_ENUM_EGL e)
+{
+    (void)e;
+    return "EGL_UNKNOWN";
+}
+
 #endif
 
 

--- a/include/glatter/glatter_platform_headers.h
+++ b/include/glatter/glatter_platform_headers.h
@@ -14,7 +14,33 @@
      - GLATTER_WINDOWS_WGL_GL
      - GLATTER_MESA_GLX_GL
      - GLATTER_MESA_EGL_GLES
+
+   When consumers bypass glatter_config.h (e.g., by defining
+   GLATTER_CONFIG_H_DEFINED and providing configuration flags via the
+   compiler command line) we still want the convenience macros that
+   glatter_config.h would normally emit.  In particular the GLES
+   profiles imply the use of the Mesa EGL + GLES platform.  Mirror that
+   logic here so that the public headers can be used without pulling in
+   glatter_config.h while still getting the correct platform selection.
    ----------------------------------------------------------- */
+
+#if (defined(GLATTER_EGL_GLES_1_1) || defined(GLATTER_EGL_GLES2_2_0) || \
+     defined(GLATTER_EGL_GLES_3_0) || defined(GLATTER_EGL_GLES_3_1)  || \
+     defined(GLATTER_EGL_GLES_3_2)) && !defined(GLATTER_MESA_EGL_GLES)
+#define GLATTER_MESA_EGL_GLES
+#endif
+
+#if !defined(GLATTER_HAS_EGL_GENERATED_HEADERS)
+#if defined(__has_include)
+#if __has_include("glatter/platforms/glatter_mesa_egl_gles/glatter_EGL_ges_decl.h")
+#define GLATTER_HAS_EGL_GENERATED_HEADERS 1
+#else
+#define GLATTER_HAS_EGL_GENERATED_HEADERS 0
+#endif
+#else
+#define GLATTER_HAS_EGL_GENERATED_HEADERS 0
+#endif
+#endif
 
 #if defined(GLATTER_WINDOWS_WGL_GL)
 
@@ -73,6 +99,13 @@
 
 /* ---------------- Any: EGL + OpenGL ES --------------------- */
 #define GLATTER_PLATFORM_DIR glatter_mesa_egl_gles
+
+#if !GLATTER_HAS_EGL_GENERATED_HEADERS
+typedef struct glatter_extension_support_status_EGL
+{
+    int dummy;
+} glatter_extension_support_status_EGL_t;
+#endif
 
 /* EGL core + extensions */
 #include "headers/khronos_egl/egl.h"


### PR DESCRIPTION
## Summary
- detect when the EGL/GLES configuration is selected without generated headers and define the platform macros accordingly
- guard EGL-specific includes behind a new detection flag and provide stubbed extension helpers so the headers still compile

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d7cf76aa0c832db544da91f0e56f7a