### PR TITLE
Handle WGL loader sentinel return values

### DIFF
--- a/include/glatter/glatter_def.h
+++ b/include/glatter/glatter_def.h
@@ -198,9 +198,11 @@ void* glatter_get_proc_address(const char* function_name)
 #endif
     }
 #elif defined(GLATTER_WGL)
-    ptr = (void*) wglGetProcAddress(function_name);
-    if (ptr == 0)
-        ptr = (void*) GetProcAddress(GetModuleHandle(TEXT("opengl32.dll")), function_name);
+    PROC a = wglGetProcAddress(function_name);
+    if (!a || a == (PROC)1 || a == (PROC)2 || a == (PROC)3 || a == (PROC)4) {
+        a = (PROC) GetProcAddress(GetModuleHandleA("opengl32.dll"), function_name);
+    }
+    ptr = (void*) a;
 #elif defined(GLATTER_GLX)
     ptr = (void*) glXGetProcAddress((const GLubyte*)function_name);
     if (ptr == 0) {


### PR DESCRIPTION
## Summary
- treat WGL sentinel values 1..4 as failed lookups when loading OpenGL entry points
- fall back to GetProcAddress on opengl32.dll when wglGetProcAddress returns a sentinel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7d5ee362c832d83dd053e960bf246