### PR TITLE
Guard GL extension support generation against missing contexts

### DIFF
--- a/include/glatter/glatter.py
+++ b/include/glatter/glatter.py
@@ -1008,13 +1008,19 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
 '''
     if (v == 'GL'):
         rv += '''
-        const uint8_t* glv = (const uint8_t*)glatter_glGetString(GL_VERSION);
-        int new_way = 0;
-        if (glv) {
-            // if this fails, something might be wrong with the implementation
-            assert((int)glv[0] > 48 && (int)glv[0] < 58);
-            new_way = (int)glv[0] > 50; // i.e. gl version is 3 or higher
+        const uint8_t* glv = NULL;
+        if (glatter_get_proc_address_GL("glGetString")) {
+            glv = (const uint8_t*)glatter_glGetString(GL_VERSION);
         }
+        int new_way = 0;
+        if (!glv) {
+            initialized = 1;
+            memcpy((void*)&ess, indexed_extensions, sizeof(ess));
+            return ess;
+        }
+        // if this fails, something might be wrong with the implementation
+        assert((int)glv[0] > 48 && (int)glv[0] < 58);
+        new_way = (int)glv[0] > 50; // i.e. gl version is 3 or higher
 
 #ifdef GL_NUM_EXTENSIONS
         if (new_way && glatter_get_proc_address_GL("glGetStringi") ) {

--- a/include/glatter/platforms/glatter_mesa_egl_gles/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_mesa_egl_gles/glatter_GL_ges_def.h
@@ -871,13 +871,19 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
     static int initialized = 0;
     if (!initialized) {
 
-        const uint8_t* glv = (const uint8_t*)glatter_glGetString(GL_VERSION);
-        int new_way = 0;
-        if (glv) {
-            // if this fails, something might be wrong with the implementation
-            assert((int)glv[0] > 48 && (int)glv[0] < 58);
-            new_way = (int)glv[0] > 50; // i.e. gl version is 3 or higher
+        const uint8_t* glv = NULL;
+        if (glatter_get_proc_address_GL("glGetString")) {
+            glv = (const uint8_t*)glatter_glGetString(GL_VERSION);
         }
+        int new_way = 0;
+        if (!glv) {
+            initialized = 1;
+            memcpy((void*)&ess, indexed_extensions, sizeof(ess));
+            return ess;
+        }
+        // if this fails, something might be wrong with the implementation
+        assert((int)glv[0] > 48 && (int)glv[0] < 58);
+        new_way = (int)glv[0] > 50; // i.e. gl version is 3 or higher
 
 #ifdef GL_NUM_EXTENSIONS
         if (new_way && glatter_get_proc_address_GL("glGetStringi") ) {

--- a/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_def.h
@@ -1209,13 +1209,19 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
     static int initialized = 0;
     if (!initialized) {
 
-        const uint8_t* glv = (const uint8_t*)glatter_glGetString(GL_VERSION);
-        int new_way = 0;
-        if (glv) {
-            // if this fails, something might be wrong with the implementation
-            assert((int)glv[0] > 48 && (int)glv[0] < 58);
-            new_way = (int)glv[0] > 50; // i.e. gl version is 3 or higher
+        const uint8_t* glv = NULL;
+        if (glatter_get_proc_address_GL("glGetString")) {
+            glv = (const uint8_t*)glatter_glGetString(GL_VERSION);
         }
+        int new_way = 0;
+        if (!glv) {
+            initialized = 1;
+            memcpy((void*)&ess, indexed_extensions, sizeof(ess));
+            return ess;
+        }
+        // if this fails, something might be wrong with the implementation
+        assert((int)glv[0] > 48 && (int)glv[0] < 58);
+        new_way = (int)glv[0] > 50; // i.e. gl version is 3 or higher
 
 #ifdef GL_NUM_EXTENSIONS
         if (new_way && glatter_get_proc_address_GL("glGetStringi") ) {

--- a/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_def.h
@@ -1207,13 +1207,19 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
     static int initialized = 0;
     if (!initialized) {
 
-        const uint8_t* glv = (const uint8_t*)glatter_glGetString(GL_VERSION);
-        int new_way = 0;
-        if (glv) {
-            // if this fails, something might be wrong with the implementation
-            assert((int)glv[0] > 48 && (int)glv[0] < 58);
-            new_way = (int)glv[0] > 50; // i.e. gl version is 3 or higher
+        const uint8_t* glv = NULL;
+        if (glatter_get_proc_address_GL("glGetString")) {
+            glv = (const uint8_t*)glatter_glGetString(GL_VERSION);
         }
+        int new_way = 0;
+        if (!glv) {
+            initialized = 1;
+            memcpy((void*)&ess, indexed_extensions, sizeof(ess));
+            return ess;
+        }
+        // if this fails, something might be wrong with the implementation
+        assert((int)glv[0] > 48 && (int)glv[0] < 58);
+        new_way = (int)glv[0] > 50; // i.e. gl version is 3 or higher
 
 #ifdef GL_NUM_EXTENSIONS
         if (new_way && glatter_get_proc_address_GL("glGetStringi") ) {


### PR DESCRIPTION
## Summary
- guard glGetString usage in the generator so extension discovery short-circuits without a current GL context
- regenerate GL extension support definitions so all platforms avoid querying extensions when glGetString is unavailable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d7d6268ccc832da6c0de0137d0e4ad