### PR TITLE
Improve loader resilience and generator parsing

### DIFF
--- a/include/glatter/glatter_config.h
+++ b/include/glatter/glatter_config.h
@@ -98,6 +98,14 @@
 ///////////////////////////////////////////////////
 //#define GLATTER_DO_NOT_INSTALL_X_ERROR_HANDLER
 
+/////////////////////////////////////
+// Windows character encoding switch //
+/////////////////////////////////////
+// Define GLATTER_WINDOWS_MBCS to treat TCHAR as CHAR when generating bindings
+// for non-UNICODE builds. The generator assumes UNICODE (TCHAR -> WCHAR) by
+// default.
+
+
 
 
 #endif


### PR DESCRIPTION
## Summary
- rewrite `get_prs` to format output using a moving pointer while keeping the existing bracket semantics
- add an extra GLES soname alias and load `opengl32.dll` explicitly when needed on Windows
- allow configuring `TCHAR` handling for non-UNICODE builds and better detect callback parameter names in the generator

## Testing
- python -m pytest tests/test_build.py

------
https://chatgpt.com/codex/tasks/task_b_68d7e6ae69f4832da626d9daf8dcdece