### PR TITLE
Fix varargs UB and harden log handler concurrency

### DIFF
--- a/include/glatter/glatter.h
+++ b/include/glatter/glatter.h
@@ -32,6 +32,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "glatter_config.h"
 #include "glatter_platform_headers.h"
 
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#include <atomic>
+#endif
+
 #ifdef __cplusplus
 
 extern "C" {

--- a/include/glatter/glatter_config.h
+++ b/include/glatter/glatter_config.h
@@ -96,6 +96,9 @@
 ///////////////////////////////////////////////////
 // X error handler switch (only relevant to GLX) //
 ///////////////////////////////////////////////////
+// Installing the GLATTER X error handler replaces the process-wide Xlib
+// handler. Define GLATTER_DO_NOT_INSTALL_X_ERROR_HANDLER to opt out and
+// install your own (for example after calling XInitThreads()).
 //#define GLATTER_DO_NOT_INSTALL_X_ERROR_HANDLER
 
 /////////////////////////////////////

--- a/include/glatter/glatter_masprintf.h
+++ b/include/glatter/glatter_masprintf.h
@@ -63,14 +63,22 @@ GLATTER_MASPRINTF_INLINE int vscprintf(const char* format, va_list ap)
 
 GLATTER_MASPRINTF_INLINE char* glatter_mvasprintf(const char* format, va_list ap)
 {
-    int len = vscprintf(format, ap);
-    if (len == -1)
+    va_list ap_len;
+    va_copy(ap_len, ap);
+    int len = vscprintf(format, ap_len);
+    va_end(ap_len);
+    if (len < 0)
         return 0;
+
     char* str = (char*)malloc((size_t)len + 1);
     if (!str)
         return 0;
-    int val = vsnprintf(str, len + 1, format, ap);
-    if (val == -1) {
+
+    va_list ap_copy;
+    va_copy(ap_copy, ap);
+    int val = vsnprintf(str, (size_t)len + 1, format, ap_copy);
+    va_end(ap_copy);
+    if (val < 0) {
         free(str);
         return 0;
     }


### PR DESCRIPTION
## Summary
- copy the variadic argument list when sizing and formatting in glatter_mvasprintf to avoid undefined behavior on MSVC
- treat the -1 sentinel from wglGetProcAddress as a failure and clarify that the optional GLX X error handler is global
- store the log handler via atomics (when available) so concurrent readers and writers remain race-free, including header-only builds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d7f1f55a64832db375fdc82ae456c8