### PR TITLE
Stop defaulting C++ includes to header-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ glClear(GL_COLOR_BUFFER_BIT);
 
 **Do not include the system GL headers** (e.g., `GL/gl.h`, `EGL/egl.h`) yourself; glatter pulls the right headers for you.
 
-Header‑only is enabled automatically for C++ when including `glatter_solo.h` or `glatter.h`. To use the compiled TU from C++ as well, define `GLATTER_NO_HEADER_ONLY` **before** including the header and add `src/glatter/glatter.c` to your build.
+Including `glatter_solo.h` in C++ enables header-only mode automatically (it is equivalent to defining `GLATTER_HEADER_ONLY` before including `glatter.h`). Including `glatter.h` directly uses the compiled translation unit path; add `src/glatter/glatter.c` to your build for both C and C++ in that case.
 
 ---
 
@@ -140,7 +140,7 @@ If `GLATTER_HAS_EGL_GENERATED_HEADERS` is off for your target, EGL/GLES helpers 
 ## 11) Integration notes
 
 - Include only `<glatter/...>` in your sources.
-- **C++:** header‑only by default; to use compiled mode define `GLATTER_NO_HEADER_ONLY` and add `src/glatter/glatter.c`.
+- **C++:** include `glatter/glatter_solo.h` for header-only, or include `glatter/glatter.h` and add `src/glatter/glatter.c` to use the compiled library path.
 - **Linking:**
   - Windows: link `opengl32` (and `EGL`/`GLES` DLLs if you use them).
   - Linux/BSD: link `GL`, `X11`, `pthread`, `dl` (and `EGL`/`GLES` if you use them).

--- a/include/glatter/glatter.h
+++ b/include/glatter/glatter.h
@@ -27,10 +27,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GLATTER_H_DEFINED
 #define GLATTER_H_DEFINED
 
-#if defined(__cplusplus) && !defined(GLATTER_HEADER_ONLY) && !defined(GLATTER_NO_HEADER_ONLY)
-#define GLATTER_HEADER_ONLY 1
-#endif
-
 #include <inttypes.h>
 
 #include "glatter_config.h"
@@ -122,6 +118,8 @@ void glatter_set_log_handler(void(*handler_ptr)(const char*));
 
 GLATTER_INLINE_OR_NOT void glatter_set_provider(int provider);
 GLATTER_INLINE_OR_NOT int  glatter_get_provider(void);
+GLATTER_INLINE_OR_NOT void* glatter_get_proc_address(const char* function_name);
+GLATTER_INLINE_OR_NOT void  glatter_bind_owner_to_current_thread(void);
 
 
 #if defined(GLATTER_GL)

--- a/include/glatter/glatter_solo.h
+++ b/include/glatter/glatter_solo.h
@@ -1,8 +1,8 @@
 #ifndef GLATTER_SOLO_H
 #define GLATTER_SOLO_H
 
-/* Enable header-only mode by default for C++ consumers unless explicitly disabled. */
-#if defined(__cplusplus) && !defined(GLATTER_HEADER_ONLY) && !defined(GLATTER_NO_HEADER_ONLY)
+/* Enable header-only mode explicitly for C++ consumers. */
+#if defined(__cplusplus) && !defined(GLATTER_HEADER_ONLY)
 #  define GLATTER_HEADER_ONLY 1
 #endif
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -230,15 +230,15 @@ def test_header_only_cpp_compiles_across_translation_units(tmp_path: Path) -> No
     )
 
 
-def test_header_only_cpp_compiles_without_manual_macros(tmp_path: Path) -> None:
-    """Verify that C++ translation units build without defining config macros."""
+def test_header_only_cpp_compiles_via_glatter_solo(tmp_path: Path) -> None:
+    """Verify that header-only mode works out of the box via glatter_solo.h."""
 
     cxx = _require_tool("c++")
 
     sources = {
         "main.cpp": textwrap.dedent(
             """
-            #include <glatter/glatter.h>
+            #include <glatter/glatter_solo.h>
 
             int helper();
 
@@ -254,7 +254,7 @@ def test_header_only_cpp_compiles_without_manual_macros(tmp_path: Path) -> None:
         + "\n",
         "helper.cpp": textwrap.dedent(
             """
-            #include <glatter/glatter.h>
+            #include <glatter/glatter_solo.h>
 
             int helper() {
                 return glatter_get_proc_address("glGetString") != nullptr;


### PR DESCRIPTION
## Summary
- stop automatically defining GLATTER_HEADER_ONLY when including glatter.h from C++
- make glatter_solo.h the explicit header-only entry point and document the new behavior
- update tests to cover glatter_solo usage and declare missing prototypes for compiled builds

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d828f72818832da8687f18262ba271