### PR TITLE
Fix GLU gating and expand Windows stub test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Handles UNICODE and MBCS builds. The generator assumes UNICODE by default; on no
 
 Two headers are meant for power users:
 
-* `glatter_config.h` Feature/platform switches. Define `GLATTER_USER_CONFIGURED` and set your own `GLATTER_*` macros to opt out of the defaults.
+* `glatter_config_user.h` Feature/platform switches. Edit these simple knobs to choose APIs, platforms, and logging behaviour. `glatter_config.h` remains the public entry point and forwards to the user file plus internal defaults/validation.
 * `glatter_platform_headers.h` The list of API headers glatter should use. If you edit this, re‑run the generator.
 
 ### Regenerating headers (optional)

--- a/include/glatter/glatter.h
+++ b/include/glatter/glatter.h
@@ -68,22 +68,22 @@ enum {
 
 
 
-#if defined(GLATTER_GL)
-	#include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GL_ges_decl.h)
+#if defined(GLATTER_GL) && GLATTER_GL
+        #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GL_ges_decl.h)
 #endif
 
-#if defined(GLATTER_GLX)
-	#include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_ges_decl.h)
+#if defined(GLATTER_GLX) && GLATTER_GLX
+        #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_ges_decl.h)
 #endif
 
-#if defined(GLATTER_EGL)
+#if defined(GLATTER_EGL) && GLATTER_EGL
 #if GLATTER_HAS_EGL_GENERATED_HEADERS
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_ges_decl.h)
 #endif
 #endif
 
-#if defined(GLATTER_WGL)
-	#include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_WGL_ges_decl.h)
+#if defined(GLATTER_WGL) && GLATTER_WGL
+        #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_WGL_ges_decl.h)
 #endif
 
 
@@ -92,7 +92,7 @@ enum {
 
     #include "glatter_def.h"
 
-    #if defined(GLATTER_LOG_ERRORS) || defined(GLATTER_LOG_CALLS)
+    #if (defined(GLATTER_LOG_ERRORS) && GLATTER_LOG_ERRORS) || (defined(GLATTER_LOG_CALLS) && GLATTER_LOG_CALLS)
         #define GLATTER_UBLOCK(rtype, cconv, name, dargs)\
             typedef rtype (cconv *glatter_##name##_t) dargs;\
             extern glatter_##name##_t glatter_##name;
@@ -121,72 +121,72 @@ GLATTER_INLINE_OR_NOT void* glatter_get_proc_address(const char* function_name);
 GLATTER_INLINE_OR_NOT void  glatter_bind_owner_to_current_thread(void);
 
 
-#if defined(GLATTER_GL)
+#if defined(GLATTER_GL) && GLATTER_GL
     GLATTER_INLINE_OR_NOT glatter_extension_support_status_GL_t  glatter_get_extension_support_GL();
     GLATTER_INLINE_OR_NOT const char* enum_to_string_GL(GLATTER_ENUM_GL e);
 #endif
 
-#if defined(GLATTER_GLX)
+#if defined(GLATTER_GLX) && GLATTER_GLX
     GLATTER_INLINE_OR_NOT glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX();
     GLATTER_INLINE_OR_NOT const char* enum_to_string_GLX(GLATTER_ENUM_GLX e);
 #endif
 
-#if defined(GLATTER_EGL)
+#if defined(GLATTER_EGL) && GLATTER_EGL
     GLATTER_INLINE_OR_NOT glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL();
     GLATTER_INLINE_OR_NOT const char* enum_to_string_EGL(GLATTER_ENUM_EGL e);
 #endif
 
-#if defined(GLATTER_WGL)
+#if defined(GLATTER_WGL) && GLATTER_WGL
     GLATTER_INLINE_OR_NOT glatter_extension_support_status_WGL_t glatter_get_extension_support_WGL();
     GLATTER_INLINE_OR_NOT const char* enum_to_string_WGL(GLATTER_ENUM_WGL e);
 #endif
-    
-#if defined (GLATTER_GLU)
+
+#if defined (GLATTER_GLU) && GLATTER_GLU
     GLATTER_INLINE_OR_NOT const char* enum_to_string_GLU(GLATTER_ENUM_GLU e);
 #endif
 
 
-#if defined(GLATTER_LOG_ERRORS) || defined(GLATTER_LOG_CALLS)
+#if (defined(GLATTER_LOG_ERRORS) && GLATTER_LOG_ERRORS) || (defined(GLATTER_LOG_CALLS) && GLATTER_LOG_CALLS)
 
-    #if defined(GLATTER_GL)
+    #if defined(GLATTER_GL) && GLATTER_GL
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GL_d.h)
     #endif
 
-    #if defined(GLATTER_GLX)
+    #if defined(GLATTER_GLX) && GLATTER_GLX
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_d.h)
     #endif
 
-    #if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
+    #if defined(GLATTER_EGL) && GLATTER_EGL && GLATTER_HAS_EGL_GENERATED_HEADERS
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_d.h)
     #endif
 
-    #if defined(GLATTER_WGL)
+    #if defined(GLATTER_WGL) && GLATTER_WGL
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_WGL_d.h)
     #endif
 
-    #if defined(GLATTER_GLU)
+    #if defined(GLATTER_GLU) && GLATTER_GLU
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLU_d.h)
     #endif
 
 #else
 
-    #if defined(GLATTER_GL)
+    #if defined(GLATTER_GL) && GLATTER_GL
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GL_r.h)
     #endif
 
-    #if defined(GLATTER_GLX)
+    #if defined(GLATTER_GLX) && GLATTER_GLX
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLX_r.h)
     #endif
 
-    #if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
+    #if defined(GLATTER_EGL) && GLATTER_EGL && GLATTER_HAS_EGL_GENERATED_HEADERS
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_EGL_r.h)
     #endif
 
-    #if defined(GLATTER_WGL)
+    #if defined(GLATTER_WGL) && GLATTER_WGL
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_WGL_r.h)
     #endif
 
-    #if defined(GLATTER_GLU)
+    #if defined(GLATTER_GLU) && GLATTER_GLU
         #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GLU_r.h)
     #endif
 

--- a/include/glatter/glatter_config.h
+++ b/include/glatter/glatter_config.h
@@ -1,180 +1,19 @@
 #ifndef GLATTER_CONFIG_H_DEFINED
 #define GLATTER_CONFIG_H_DEFINED
 
-
-/* =========================
-   Zero-config defaults
-   ========================= */
-
-/* If the user didn't configure Glatter manually, pick sensible defaults. */
-#if !defined(GLATTER_USER_CONFIGURED) || (GLATTER_USER_CONFIGURED == 0)
-
-    /* Core GL wrappers are available unless explicitly disabled. */
-    #ifndef GLATTER_GL
-        #define GLATTER_GL 1
-    #endif
-
-    /* Platform defaults based on the host toolchain. */
-    #if defined(_WIN32)
-        #ifndef GLATTER_WINDOWS_WGL_GL
-            #define GLATTER_WINDOWS_WGL_GL 1
-        #endif
-        #ifndef GLATTER_WGL
-            #define GLATTER_WGL 1
-        #endif
-    #elif defined(__ANDROID__) || defined(__EMSCRIPTEN__)
-        #ifndef GLATTER_MESA_EGL_GLES
-            #define GLATTER_MESA_EGL_GLES 1
-        #endif
-        #ifndef GLATTER_EGL
-            #define GLATTER_EGL 1
-        #endif
-        /* Default to the highest GLES profile shipped with the headers. */
-        #ifndef GLATTER_EGL_GLES_3_2
-            #define GLATTER_EGL_GLES_3_2 1
-        #endif
-    #else
-        #ifndef GLATTER_MESA_GLX_GL
-            #define GLATTER_MESA_GLX_GL 1
-        #endif
-        #ifndef GLATTER_GLX
-            #define GLATTER_GLX 1
-        #endif
-    #endif
-
-#endif /* !defined(GLATTER_USER_CONFIGURED) || (GLATTER_USER_CONFIGURED == 0) */
-
-
-#ifndef GLATTER_WSI_AUTO_VALUE
-#define GLATTER_WSI_AUTO_VALUE 0
-#define GLATTER_WSI_WGL_VALUE  1
-#define GLATTER_WSI_GLX_VALUE  2
-#define GLATTER_WSI_EGL_VALUE  3
+/* 1) Pull user knobs if present locally; else fall back to installed copy */
+#if defined(__has_include)
+#  if __has_include("glatter_config_user.h")
+#    include "glatter_config_user.h"
+#  else
+#    include <glatter/glatter_config_user.h>
+#  endif
+#else
+#  include <glatter/glatter_config_user.h>
 #endif
 
+/* 2) Internal mapping + defaults + validation */
+#include <glatter/glatter_config_internal.h>
+#include <glatter/glatter_config_validate.h>
 
-/////////////////////////////////
-// Explicit platform selection //
-/////////////////////////////////
-//
-// NOTE: For GLES the platform must be specified explicitly.
-//
-// #define GLATTER_WINDOWS_WGL_GL
-// #define GLATTER_MESA_GLX_GL
-// #define GLATTER_MESA_EGL_GLES
-// #define GLATTER_EGL_GLES_1_1
-// #define GLATTER_EGL_GLES2_2_0
-// #define GLATTER_EGL_GLES_3_0
-// #define GLATTER_EGL_GLES_3_1
-// #define GLATTER_EGL_GLES_3_2
-
-// If no platform is defined, it will be set according to the operating system.
-#if !defined(GLATTER_WINDOWS_WGL_GL) &&\
-    !defined(GLATTER_MESA_GLX_GL)    &&\
-    !defined(GLATTER_MESA_EGL_GLES)  &&\
-    !defined(GLATTER_EGL_GLES_1_1)   &&\
-    !defined(GLATTER_EGL_GLES2_2_0)  &&\
-    !defined(GLATTER_EGL_GLES_3_0)   &&\
-    !defined(GLATTER_EGL_GLES_3_1)   &&\
-    !defined(GLATTER_EGL_GLES_3_2)
-
-#if defined(_WIN32)
-    #define GLATTER_WINDOWS_WGL_GL 1
-#elif defined(__linux__)
-    #define GLATTER_MESA_GLX_GL 1
-#endif
-
-#endif
-
-
-#if defined(GLATTER_EGL_GLES_1_1)  ||\
-    defined(GLATTER_EGL_GLES2_2_0) ||\
-    defined(GLATTER_EGL_GLES_3_0)  ||\
-    defined(GLATTER_EGL_GLES_3_1)  ||\
-    defined(GLATTER_EGL_GLES_3_2)
-
-    #ifndef GLATTER_MESA_EGL_GLES
-        #define GLATTER_MESA_EGL_GLES 1
-    #endif
-
-#endif
-
-
-////////////////////////////////
-// Explicit wrapper selection //
-////////////////////////////////
-// #define GLATTER_GL
-// #define GLATTER_EGL
-// #define GLATTER_WGL
-// #define GLATTER_GLX
-// #define GLATTER_GLU
-
-// If no wrapper is defined, GL is set, and one of ELG/GLX/WGL depending on the platform
-#if !defined(GLATTER_GL) && !defined(GLATTER_EGL) && !defined(GLATTER_WGL) &&\
-    !defined(GLATTER_GLX) && !defined(GLATTER_GLU)
-
-    #define GLATTER_GL 1
-    #if defined(GLATTER_WINDOWS_WGL_GL)
-        #define GLATTER_WGL 1
-    #elif defined (GLATTER_MESA_GLX_GL)
-        #define GLATTER_GLX 1
-    #else // GLES
-        #define GLATTER_EGL 1
-    #endif
-
-    // #define GLATTER_GLU  // GLU is not enabled by default
-
-#endif
-
-
-
-//////////////////////////////////////
-// Debugging functionality switches //
-//////////////////////////////////////
-// #define GLATTER_LOG_ERRORS
-// #define GLATTER_LOG_CALLS
-
-// Unless specified otherwise, GL errors will be logged in debug builds
-#if !defined(GLATTER_LOG_ERRORS) && !defined(GLATTER_LOG_CALLS)
-    #ifndef NDEBUG
-        #define GLATTER_LOG_ERRORS 1
-    #endif
-#endif
-
-
-
-///////////////////////////////////////////////////
-// X error handler switch (only relevant to GLX) //
-///////////////////////////////////////////////////
-// Installing the GLATTER X error handler replaces the process-wide Xlib
-// handler. Define GLATTER_DO_NOT_INSTALL_X_ERROR_HANDLER to opt out and
-// install your own (for example after calling XInitThreads()).
-//#define GLATTER_DO_NOT_INSTALL_X_ERROR_HANDLER
-
-////////////////////////////////////////////////////////
-// Thread ownership enforcement (header-only C++) switch //
-////////////////////////////////////////////////////////
-// Define GLATTER_REQUIRE_EXPLICIT_OWNER_BIND to disable the automatic
-// owner-thread binding performed the first time a wrapped call executes in
-// header-only builds. When set, applications must call
-// glatter_bind_owner_to_current_thread() on the intended render thread before
-// making GL calls; otherwise the library aborts to signal the configuration
-// error.
-//#define GLATTER_REQUIRE_EXPLICIT_OWNER_BIND
-
-/////////////////////////////////////
-// Windows character encoding switch //
-/////////////////////////////////////
-// Define GLATTER_WINDOWS_MBCS to treat TCHAR as CHAR when generating bindings
-// for non-UNICODE builds. The generator assumes UNICODE (TCHAR -> WCHAR) by
-// default.
-#if defined(_WIN32)
-# if !defined(UNICODE) && !defined(_UNICODE)
-#   ifndef GLATTER_WINDOWS_MBCS
-#     define GLATTER_WINDOWS_MBCS 1
-#   endif
-# endif
-#endif
-
-
-#endif
+#endif /* GLATTER_CONFIG_H_DEFINED */

--- a/include/glatter/glatter_config_internal.h
+++ b/include/glatter/glatter_config_internal.h
@@ -1,0 +1,160 @@
+#ifndef GLATTER_CONFIG_INTERNAL_H
+#define GLATTER_CONFIG_INTERNAL_H
+
+/* ------------------------------------------------------------------------- */
+/* 1) Legacy compatibility: map old-style toggles onto the new enums/flags.  */
+/* ------------------------------------------------------------------------- */
+
+/* Legacy platform selectors imply the new GLATTER_PLATFORM value. */
+#if defined(GLATTER_WINDOWS_WGL_GL)
+#  undef GLATTER_PLATFORM
+#  define GLATTER_PLATFORM GLATTER_PLATFORM_WGL
+#endif
+#if defined(GLATTER_MESA_GLX_GL)
+#  undef GLATTER_PLATFORM
+#  define GLATTER_PLATFORM GLATTER_PLATFORM_GLX
+#endif
+#if defined(GLATTER_MESA_EGL_GLES)
+#  undef GLATTER_PLATFORM
+#  define GLATTER_PLATFORM GLATTER_PLATFORM_EGL
+#endif
+
+/* Legacy GLES profiles imply the consolidated GLATTER_GLES_VERSION knob. */
+#if defined(GLATTER_EGL_GLES_1_1)
+#  undef GLATTER_GLES_VERSION
+#  define GLATTER_GLES_VERSION 11
+#endif
+#if defined(GLATTER_EGL_GLES2_2_0)
+#  undef GLATTER_GLES_VERSION
+#  define GLATTER_GLES_VERSION 20
+#endif
+#if defined(GLATTER_EGL_GLES_3_0)
+#  undef GLATTER_GLES_VERSION
+#  define GLATTER_GLES_VERSION 30
+#endif
+#if defined(GLATTER_EGL_GLES_3_1)
+#  undef GLATTER_GLES_VERSION
+#  define GLATTER_GLES_VERSION 31
+#endif
+#if defined(GLATTER_EGL_GLES_3_2)
+#  undef GLATTER_GLES_VERSION
+#  define GLATTER_GLES_VERSION 32
+#endif
+
+/* ------------------------------------------------------------------------- */
+/* 2) Zero-config defaults (if the user did not override the knobs).         */
+/* ------------------------------------------------------------------------- */
+
+#ifndef GLATTER_GL
+#  define GLATTER_GL 1
+#endif
+#ifndef GLATTER_GLU
+#  define GLATTER_GLU 0
+#endif
+#ifndef GLATTER_GLES_VERSION
+#  define GLATTER_GLES_VERSION 0
+#endif
+#ifndef GLATTER_PLATFORM
+#  define GLATTER_PLATFORM GLATTER_PLATFORM_AUTO
+#endif
+#ifndef GLATTER_LOG_ERRORS
+#  define GLATTER_LOG_ERRORS 1
+#endif
+#ifndef GLATTER_LOG_CALLS
+#  define GLATTER_LOG_CALLS 0
+#endif
+#ifndef GLATTER_REQUIRE_EXPLICIT_OWNER_BIND
+#  define GLATTER_REQUIRE_EXPLICIT_OWNER_BIND 0
+#endif
+#ifndef GLATTER_INSTALL_X_ERROR_HANDLER
+#  define GLATTER_INSTALL_X_ERROR_HANDLER 1
+#endif
+
+/* ------------------------------------------------------------------------- */
+/* 3) Platform mapping / auto-detect                                         */
+/* ------------------------------------------------------------------------- */
+
+#if (GLATTER_PLATFORM == GLATTER_PLATFORM_WGL)
+#  define GLATTER_WINDOWS_WGL_GL 1
+#  define GLATTER_WGL 1
+#elif (GLATTER_PLATFORM == GLATTER_PLATFORM_GLX)
+#  define GLATTER_MESA_GLX_GL 1
+#  define GLATTER_GLX 1
+#elif (GLATTER_PLATFORM == GLATTER_PLATFORM_EGL)
+#  define GLATTER_MESA_EGL_GLES 1
+#  define GLATTER_EGL 1
+#elif (GLATTER_PLATFORM == GLATTER_PLATFORM_AUTO)
+   /* Preserve the historical zero-config behaviour. */
+#  if defined(_WIN32)
+#    define GLATTER_WINDOWS_WGL_GL 1
+#    define GLATTER_WGL 1
+#  elif defined(__ANDROID__) || defined(__EMSCRIPTEN__)
+#    define GLATTER_MESA_EGL_GLES 1
+#    define GLATTER_EGL 1
+#    if GLATTER_GLES_VERSION == 0
+#      undef GLATTER_GLES_VERSION
+#      define GLATTER_GLES_VERSION 32
+#      define GLATTER_EGL_GLES_3_2 1
+#    endif
+#  else
+#    define GLATTER_MESA_GLX_GL 1
+#    define GLATTER_GLX 1
+#  endif
+#else
+#  error "Invalid GLATTER_PLATFORM value"
+#endif
+
+/* ------------------------------------------------------------------------- */
+/* 4) Derive GLES/EGL feature flags from the consolidated version switch.    */
+/* ------------------------------------------------------------------------- */
+
+#if GLATTER_GLES_VERSION
+#  define GLATTER_EGL 1
+#  if   GLATTER_GLES_VERSION == 11
+#    define GLATTER_EGL_GLES_1_1 1
+#  elif GLATTER_GLES_VERSION == 20
+#    define GLATTER_EGL_GLES2_2_0 1
+#  elif GLATTER_GLES_VERSION == 30
+#    define GLATTER_EGL_GLES_3_0 1
+#  elif GLATTER_GLES_VERSION == 31
+#    define GLATTER_EGL_GLES_3_1 1
+#  elif GLATTER_GLES_VERSION == 32
+#    define GLATTER_EGL_GLES_3_2 1
+#  else
+#    error "Invalid GLATTER_GLES_VERSION: allowed {0,11,20,30,31,32}"
+#  endif
+#endif
+
+/* If no API toggles were left enabled, fall back to core GL. */
+#if !(defined(GLATTER_GL) && GLATTER_GL) && \
+    !(defined(GLATTER_EGL) && GLATTER_EGL) && \
+    !(defined(GLATTER_WGL) && GLATTER_WGL) && \
+    !(defined(GLATTER_GLX) && GLATTER_GLX) && \
+    !(defined(GLATTER_GLU) && GLATTER_GLU)
+#  define GLATTER_GL 1
+#  if defined(GLATTER_WINDOWS_WGL_GL)
+#    define GLATTER_WGL 1
+#  elif defined(GLATTER_MESA_GLX_GL)
+#    define GLATTER_GLX 1
+#  else
+#    define GLATTER_EGL 1
+#  endif
+#endif
+
+/* ------------------------------------------------------------------------- */
+/* 5) Auxiliary compatibility flags.                                          */
+/* ------------------------------------------------------------------------- */
+
+#if !GLATTER_INSTALL_X_ERROR_HANDLER
+#  define GLATTER_DO_NOT_INSTALL_X_ERROR_HANDLER 1
+#endif
+
+#if defined(_WIN32)
+#  if !defined(UNICODE) && !defined(_UNICODE)
+#    ifndef GLATTER_WINDOWS_MBCS
+#      define GLATTER_WINDOWS_MBCS 1
+#    endif
+#  endif
+#endif
+
+#endif /* GLATTER_CONFIG_INTERNAL_H */

--- a/include/glatter/glatter_config_user.h
+++ b/include/glatter/glatter_config_user.h
@@ -1,0 +1,30 @@
+#ifndef GLATTER_CONFIG_USER_H
+#define GLATTER_CONFIG_USER_H
+
+/* == APIs (choose what you need) == */
+#define GLATTER_GL                 1   /* 1=enable, 0=disable */
+#define GLATTER_GLU                0
+/* GLES: set version. Allowed: 0, 11, 20, 30, 31, 32 */
+#define GLATTER_GLES_VERSION       0   /* 0 = no GLES */
+
+/* == Platform / WSI selection == */
+#define GLATTER_PLATFORM_AUTO      0
+#define GLATTER_PLATFORM_WGL       1
+#define GLATTER_PLATFORM_GLX       2
+#define GLATTER_PLATFORM_EGL       3
+
+#ifndef GLATTER_PLATFORM
+#  define GLATTER_PLATFORM         GLATTER_PLATFORM_AUTO
+#endif
+
+/* == Logging == */
+#define GLATTER_LOG_ERRORS         1
+#define GLATTER_LOG_CALLS          0
+
+/* == Threading / Ownership == */
+#define GLATTER_REQUIRE_EXPLICIT_OWNER_BIND 0
+
+/* == X11 == */
+#define GLATTER_INSTALL_X_ERROR_HANDLER    1   /* 0 to opt-out */
+
+#endif /* GLATTER_CONFIG_USER_H */

--- a/include/glatter/glatter_config_validate.h
+++ b/include/glatter/glatter_config_validate.h
@@ -1,0 +1,12 @@
+#ifndef GLATTER_CONFIG_VALIDATE_H
+#define GLATTER_CONFIG_VALIDATE_H
+
+#if (defined(GLATTER_GLX) && GLATTER_GLX) && (defined(GLATTER_WGL) && GLATTER_WGL)
+#  error "Choose exactly one desktop WSI: GLX or WGL (or use AUTO)."
+#endif
+
+#if GLATTER_GLES_VERSION && !(defined(GLATTER_EGL) && GLATTER_EGL)
+#  error "GLES requires EGL. Set GLATTER_PLATFORM to EGL or AUTO."
+#endif
+
+#endif /* GLATTER_CONFIG_VALIDATE_H */

--- a/include/glatter/glatter_platform_headers.h
+++ b/include/glatter/glatter_platform_headers.h
@@ -84,12 +84,12 @@
 #include "headers/khronos_gl/wglext.h"
 
 /* Optional GLU */
-#if defined(GLATTER_GLU)
+#if defined(GLATTER_GLU) && GLATTER_GLU
 #include "headers/windows_gl_basic/GLU.h"
 #endif
 
 /* Sanity: no incompatible wrappers with this platform */
-#if defined(GLATTER_GLX) || defined(GLATTER_EGL)
+#if (defined(GLATTER_GLX) && GLATTER_GLX) || (defined(GLATTER_EGL) && GLATTER_EGL)
 #error One of the wrappers defined is not relevant to the selected platform. Please review your glatter_config.h.
 #endif
 
@@ -110,12 +110,12 @@
 #include "headers/khronos_gl/glxext.h"
 
 /* Optional GLU (your GLU lives under sgi_glu) */
-#if defined(GLATTER_GLU)
+#if defined(GLATTER_GLU) && GLATTER_GLU
 #include "headers/sgi_glu/glu.h"
 #endif
 
 /* Sanity: no incompatible wrappers with this platform */
-#if defined(GLATTER_WGL) || defined(GLATTER_EGL)
+#if (defined(GLATTER_WGL) && GLATTER_WGL) || (defined(GLATTER_EGL) && GLATTER_EGL)
 #error One of the wrappers defined is not relevant to the selected platform. Please review your glatter_config.h.
 #endif
 
@@ -152,7 +152,7 @@ typedef struct glatter_extension_support_status_EGL
 #endif
 
 /* Sanity: no incompatible wrappers with this platform */
-#if defined(GLATTER_WGL) || defined(GLATTER_GLX)
+#if (defined(GLATTER_WGL) && GLATTER_WGL) || (defined(GLATTER_GLX) && GLATTER_GLX)
 #error One of the wrappers defined is not relevant to the selected platform. Please review your glatter_config.h.
 #endif
 
@@ -195,7 +195,7 @@ typedef struct glatter_extension_support_status_EGL
    These are always available, independent of platform branch.
    You can tighten them later (e.g., EGLint for EGL) and regenerate.
    ----------------------------------------------------------- */
-#ifdef GLATTER_GL
+#if defined(GLATTER_GL) && GLATTER_GL
 typedef GLenum GLATTER_ENUM_GL;
 #else
 typedef unsigned int GLATTER_ENUM_GL;
@@ -204,13 +204,13 @@ typedef unsigned int GLATTER_ENUM_GL;
 typedef unsigned int GLATTER_ENUM_GLX;
 typedef unsigned int GLATTER_ENUM_WGL;
 
-#ifdef GLATTER_GLU
+#if defined(GLATTER_GLU) && GLATTER_GLU
 typedef GLUenum GLATTER_ENUM_GLU;
 #else
 typedef unsigned int GLATTER_ENUM_GLU;
 #endif
 
-#ifdef GLATTER_EGL
+#if defined(GLATTER_EGL) && GLATTER_EGL
 typedef EGLint GLATTER_ENUM_EGL;
 #else
 typedef int GLATTER_ENUM_EGL;

--- a/include/glatter/glatter_threads_internal.h
+++ b/include/glatter/glatter_threads_internal.h
@@ -88,6 +88,16 @@
 #  define GLATTER_ONCE_RETURN(val)          ((void)0)
 #endif
 
+#if !GLATTER_USE_ATOMICS && !GLATTER_INTERNAL_SINGLE_THREADED
+#  ifdef _WIN32
+#    define GLATTER_ONCE_CB_TYPE BOOL (CALLBACK *)(PINIT_ONCE, PVOID, PVOID*)
+#  else
+#    define GLATTER_ONCE_CB_TYPE void (*)(void)
+#  endif
+#else
+#  define GLATTER_ONCE_CB_TYPE void (*)(void)
+#endif
+
 #ifndef GLATTER_ONCE_CB_UNUSED
 #  define GLATTER_ONCE_CB_UNUSED()          (void)0
 #endif

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -461,7 +461,30 @@ def test_cpp_program_links_against_static_library(tmp_path: Path) -> None:
     )
 
 
-def test_wgl_headers_compile_with_stubs(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "config_flags",
+    (
+        pytest.param(
+            (
+                "-D_WIN32",
+                "-DGLATTER_CONFIG_H_DEFINED",
+                "-DGLATTER_GL=1",
+                "-DGLATTER_WGL=1",
+                "-DGLATTER_WINDOWS_WGL_GL=1",
+                "-D__STDC_NO_ATOMICS__=1",
+            ),
+            id="manual-config",
+        ),
+        pytest.param(
+            (
+                "-D_WIN32",
+                "-D__STDC_NO_ATOMICS__=1",
+            ),
+            id="default-config",
+        ),
+    ),
+)
+def test_wgl_headers_compile_with_stubs(config_flags: tuple[str, ...], tmp_path: Path) -> None:
     """Verify WGL-enabled builds compile when using stubbed Windows headers."""
 
     cc = _require_tool("cc")
@@ -486,15 +509,6 @@ def test_wgl_headers_compile_with_stubs(tmp_path: Path) -> None:
         ).strip()
         + "\n"
     )
-
-    config_flags = [
-        "-D_WIN32",
-        "-DGLATTER_CONFIG_H_DEFINED",
-        "-DGLATTER_GL=1",
-        "-DGLATTER_WGL=1",
-        "-DGLATTER_WINDOWS_WGL_GL=1",
-        "-D__STDC_NO_ATOMICS__=1",
-    ]
 
     _run_command(
         [


### PR DESCRIPTION
## Summary
- treat GLU/GL/EGL selection macros as true/false flags across headers so disabled knobs no longer pull in GLU types or generated includes
- adjust internal defaults and validation logic to respect zero-valued knobs when deciding on fallbacks and invariants
- run the WGL stub compile test with both manual and default configuration flags to catch regressions like the missing GLUenum error

## Testing
- python3 tests/test_build.py

------
https://chatgpt.com/codex/tasks/task_b_68d92e9f6dc8832dbe7dc6e6b93bc844