### PR TITLE
Improve loader safety and owner binding controls

### DIFF
--- a/src/glatter/glatter.c
+++ b/src/glatter/glatter.c
@@ -20,9 +20,19 @@
 #if defined(_WIN32)
 INIT_ONCE glatter_thread_once = INIT_ONCE_STATIC_INIT;
 DWORD     glatter_thread_id   = 0;
+int       glatter_owner_bound_explicitly = 0;
+int       glatter_owner_thread_initialized = 0;
 #elif defined(__APPLE__) || defined(__unix__)
 pthread_once_t glatter_thread_once = PTHREAD_ONCE_INIT;
 pthread_t      glatter_thread_id;
+int            glatter_owner_bound_explicitly = 0;
+int            glatter_owner_thread_initialized = 0;
 #else
 #error "Unsupported platform"
 #endif
+
+#if defined(__GNUC__)
+__attribute__((visibility("default")))
+#endif
+const int glatter_build_mode_separate = 1;
+/* Link-time guard: fails the build if both header-only and separate-build are linked. */

--- a/tests/test_glatter_log_null.c
+++ b/tests/test_glatter_log_null.c
@@ -29,6 +29,8 @@ char* glatter_masprintf(const char* format, ...);
 
 pthread_once_t glatter_thread_once = PTHREAD_ONCE_INIT;
 pthread_t      glatter_thread_id;
+int            glatter_owner_bound_explicitly = 0;
+int            glatter_owner_thread_initialized = 0;
 
 static char        g_last_log_buffer[1024];
 static const char* g_last_log_message = NULL;


### PR DESCRIPTION
## Summary
- freeze log handler updates in no-atomics builds and throttle cross-thread warnings to avoid log spam
- respect explicit owner binding, add a debug abort policy for missing symbols, and guard against mixing header-only and separate builds
- harden the Windows loader with optional secure DLL loading and lock AUTO WSI selection to the first resolved stack

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d959d4e664832d8980e1097f8e047e