### PR TITLE
Fix TCHAR logging and improve portability

### DIFF
--- a/include/glatter/glatter.py
+++ b/include/glatter/glatter.py
@@ -268,19 +268,18 @@ class Function_argument:
         # 1. is api-enum
         if (bool(mm)):
             return ['%s', 'enum_to_string_' + mm.group('family') + '(' + self.name + ')']
-        if self.is_pointer:
-            return ['%p', '(void*)'+self.name]
-
         argtype = self.type
         while argtype in typedefs:
             next_type = typedefs[argtype]
             if next_type == argtype:
                 break
             argtype = next_type
-
         # Handle TCHAR* specially (UNICODE vs. MBCS decided at compile/run time)
         if re.match(r'^(const\s+)?TCHAR\s*\*$', argtype):
             return ['%s', 'glatter_pr_tstr(' + self.name + ')']
+
+        if self.is_pointer:
+            return ['%p', '(void*)'+self.name]
 
         if '*' in argtype:
             return ['%p', '(void*)'+self.name]

--- a/include/glatter/glatter_masprintf.h
+++ b/include/glatter/glatter_masprintf.h
@@ -22,42 +22,29 @@
 # endif
 #endif
 
-/*
- * vscprintf:
- * MSVC implements this as _vscprintf, thus we just 'symlink' it here
- * GNU-C-compatible compilers do not implement this, thus we implement it here
+/* Note: One definition per toolchain, marked GLATTER_MASPRINTF_INLINE (static inline),
+ * so no ODR/multiple-definition issues across TUs or header-only builds.
+ */
+
+/* vscprintf:
+ * MSVC provides _vscprintf; others use the C99 vsnprintf(NULL, 0, ...).
+ * Exactly one definition is included per toolchain, and it is inline.
  */
 #ifdef _MSC_VER
-#define vscprintf _vscprintf
-#elif !defined(__GNUC__)
+#  define vscprintf _vscprintf
+#else
 GLATTER_MASPRINTF_INLINE int vscprintf(const char* format, va_list ap)
 {
     va_list ap_copy;
     va_copy(ap_copy, ap);
-    int retval = vsnprintf(NULL, 0, format, ap_copy);
+    int n = vsnprintf(NULL, 0, format, ap_copy);
     va_end(ap_copy);
-    return retval;
+    return n;
 }
-#endif
-
-
-#ifdef __GNUC__
-GLATTER_MASPRINTF_INLINE int vscprintf(const char* format, va_list ap);
 #endif
 
 GLATTER_MASPRINTF_INLINE char* glatter_mvasprintf(const char* format, va_list ap);
 GLATTER_MASPRINTF_INLINE char* glatter_masprintf(const char* format, ...);
-
-#ifdef __GNUC__
-GLATTER_MASPRINTF_INLINE int vscprintf(const char* format, va_list ap)
-{
-    va_list ap_copy;
-    va_copy(ap_copy, ap);
-    int retval = vsnprintf(NULL, 0, format, ap_copy);
-    va_end(ap_copy);
-    return retval;
-}
-#endif
 
 
 


### PR DESCRIPTION
## Summary
- ensure the generator resolves TCHAR pointer arguments before the generic pointer fallback so TCHAR strings print via glatter_pr_tstr
- add a TLS ring buffer for TCHAR logging, emit a fallback TLS warning, and document threading behavior for loader and GLX error handling
- unify the vscprintf shim across toolchains and add clarifying diagnostics comments around logging and atomic resolution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d962d97aa4832d8f7d0b283e294a4f