### PR TITLE
Fix MSVC atomic pointer casts

### DIFF
--- a/include/glatter/glatter_atomic.h
+++ b/include/glatter/glatter_atomic.h
@@ -23,12 +23,14 @@
 
 #elif defined(_MSC_VER)
 #  include <windows.h>
+#  include <stdint.h>
    typedef void* glatter_atomic_voidp;
-#  define glatter_atomic(T)          glatter_atomic_voidp
-#  define GLATTER_ATOMIC_LOAD(a)     (InterlockedCompareExchangePointer(&(a), NULL, NULL))
-#  define GLATTER_ATOMIC_STORE(a,v)  ((void)InterlockedExchangePointer(&(a),(PVOID)(v)))
+#  define GLATTER_ATOMIC_CAST_PTR(v)      ((PVOID)(uintptr_t)(v))
+#  define glatter_atomic(T)               glatter_atomic_voidp
+#  define GLATTER_ATOMIC_LOAD(a)          (InterlockedCompareExchangePointer(&(a), NULL, NULL))
+#  define GLATTER_ATOMIC_STORE(a,v)       ((void)InterlockedExchangePointer(&(a), GLATTER_ATOMIC_CAST_PTR(v)))
 #  define GLATTER_ATOMIC_CAS(a,exp,des) \
-      (InterlockedCompareExchangePointer(&(a),(PVOID)(des),(PVOID)(exp)) == (PVOID)(exp))
+      (InterlockedCompareExchangePointer(&(a), GLATTER_ATOMIC_CAST_PTR(des), GLATTER_ATOMIC_CAST_PTR(exp)) == GLATTER_ATOMIC_CAST_PTR(exp))
 
 #else
 #  define glatter_atomic(T)          T


### PR DESCRIPTION
## Summary
- replace log handler storage with unconditional atomics and guard updates with a frozen flag
- freeze the handler during the first log emission to avoid races with late setter calls
- track GLX errors with a thread-local flag, make glatter_check_error_GLX meaningful, and log the originating file/line when a failure is detected
- fix the MSVC atomic helper casts so integer flags do not trigger pointer-size warnings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d97adf3238832daaa3752c28f2df6b