### PR TITLE
Atomicize owner thread flags

### DIFF
--- a/src/glatter/glatter.c
+++ b/src/glatter/glatter.c
@@ -28,6 +28,7 @@
 
 /* This will include platform headers in the correct, internal order. */
 #include <glatter/glatter_def.h>
+#include <glatter/glatter_atomic.h>
 
 /* C/C++ compiled mode: globals are deliberate.
  * Header-only C++ uses function-local statics; compiled mode centralizes state
@@ -36,13 +37,15 @@
 #if defined(_WIN32)
 INIT_ONCE glatter_thread_once = INIT_ONCE_STATIC_INIT;
 DWORD     glatter_thread_id   = 0;
-int       glatter_owner_bound_explicitly = 0;
-int       glatter_owner_thread_initialized = 0;
+/* Explicit INIT keeps intent clear; static zero-init would also work but is less obvious. */
+glatter_atomic_int glatter_owner_bound_explicitly   = GLATTER_ATOMIC_INT_INIT(0);
+glatter_atomic_int glatter_owner_thread_initialized = GLATTER_ATOMIC_INT_INIT(0);
 #elif defined(__APPLE__) || defined(__unix__)
 pthread_once_t glatter_thread_once = PTHREAD_ONCE_INIT;
 pthread_t      glatter_thread_id;
-int            glatter_owner_bound_explicitly = 0;
-int            glatter_owner_thread_initialized = 0;
+/* Explicit INIT keeps intent clear; static zero-init would also work but is less obvious. */
+glatter_atomic_int            glatter_owner_bound_explicitly   = GLATTER_ATOMIC_INT_INIT(0);
+glatter_atomic_int            glatter_owner_thread_initialized = GLATTER_ATOMIC_INT_INIT(0);
 #else
 #error "Unsupported platform"
 #endif

--- a/tests/test_glatter_log_null.c
+++ b/tests/test_glatter_log_null.c
@@ -29,8 +29,8 @@ char* glatter_masprintf(const char* format, ...);
 
 pthread_once_t glatter_thread_once = PTHREAD_ONCE_INIT;
 pthread_t      glatter_thread_id;
-int            glatter_owner_bound_explicitly = 0;
-int            glatter_owner_thread_initialized = 0;
+glatter_atomic_int            glatter_owner_bound_explicitly   = GLATTER_ATOMIC_INT_INIT(0);
+glatter_atomic_int            glatter_owner_thread_initialized = GLATTER_ATOMIC_INT_INIT(0);
 
 static char        g_last_log_buffer[1024];
 static const char* g_last_log_message = NULL;


### PR DESCRIPTION
## Summary
- convert the owner-thread flags to `glatter_atomic_int` and guard all reads/writes with the atomic helpers
- initialize the atomic globals with explicit `GLATTER_ATOMIC_INT_INIT` macros in the compiled TU and test harness

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d9af938fb8832d94fea79933a14a1a