### PR TITLE
Lock AUTO WSI selection with single CAS

### DIFF
--- a/include/glatter/glatter_def.h
+++ b/include/glatter/glatter_def.h
@@ -702,6 +702,17 @@ static int glatter_normalize_requested_wsi_(int requested)
     return requested;
 }
 
+/* Lock in WSI exactly once: AUTO -> {WGL,GLX,EGL}. Returns 1 if we won. */
+static GLATTER_INLINE int glatter_select_wsi_once_(glatter_loader_state* state, int chosen)
+{
+    int expected = GLATTER_WSI_AUTO_VALUE;
+    if (GLATTER_ATOMIC_INT_CAS(state->requested, expected, chosen)) {
+        GLATTER_ATOMIC_INT_STORE(state->wsi_explicit, 1);
+        return 1;
+    }
+    return 0;
+}
+
 static void glatter_decide_wsi_once_(glatter_loader_state* state)
 {
     int requested = GLATTER_ATOMIC_INT_LOAD(state->requested);
@@ -839,9 +850,8 @@ void* glatter_get_proc_address(const char* function_name)
     void* ptr = glatter_windows_resolve_wgl(state, function_name);
     if (ptr) {
         GLATTER_ATOMIC_INT_STORE(state->active, GLATTER_WSI_WGL_VALUE);
-        if (requested == GLATTER_WSI_AUTO_VALUE && !GLATTER_ATOMIC_INT_LOAD(state->wsi_explicit)) {
-            GLATTER_ATOMIC_INT_STORE(state->requested, GLATTER_WSI_WGL_VALUE);
-            GLATTER_ATOMIC_INT_STORE(state->wsi_explicit, 1);
+        if (requested == GLATTER_WSI_AUTO_VALUE) {
+            (void)glatter_select_wsi_once_(state, GLATTER_WSI_WGL_VALUE);
         }
         return ptr;
     }
@@ -849,9 +859,8 @@ void* glatter_get_proc_address(const char* function_name)
     ptr = glatter_windows_resolve_egl(state, function_name);
     if (ptr) {
         GLATTER_ATOMIC_INT_STORE(state->active, GLATTER_WSI_EGL_VALUE);
-        if (requested == GLATTER_WSI_AUTO_VALUE && !GLATTER_ATOMIC_INT_LOAD(state->wsi_explicit)) {
-            GLATTER_ATOMIC_INT_STORE(state->requested, GLATTER_WSI_EGL_VALUE);
-            GLATTER_ATOMIC_INT_STORE(state->wsi_explicit, 1);
+        if (requested == GLATTER_WSI_AUTO_VALUE) {
+            (void)glatter_select_wsi_once_(state, GLATTER_WSI_EGL_VALUE);
         }
         return ptr;
     }
@@ -872,9 +881,8 @@ void* glatter_get_proc_address(const char* function_name)
     void* ptr = glatter_linux_lookup_glx(state, function_name);
     if (ptr) {
         GLATTER_ATOMIC_INT_STORE(state->active, GLATTER_WSI_GLX_VALUE);
-        if (requested == GLATTER_WSI_AUTO_VALUE && !GLATTER_ATOMIC_INT_LOAD(state->wsi_explicit)) {
-            GLATTER_ATOMIC_INT_STORE(state->requested, GLATTER_WSI_GLX_VALUE);
-            GLATTER_ATOMIC_INT_STORE(state->wsi_explicit, 1);
+        if (requested == GLATTER_WSI_AUTO_VALUE) {
+            (void)glatter_select_wsi_once_(state, GLATTER_WSI_GLX_VALUE);
         }
         return ptr;
     }
@@ -882,9 +890,8 @@ void* glatter_get_proc_address(const char* function_name)
     ptr = glatter_linux_lookup_egl(state, function_name);
     if (ptr) {
         GLATTER_ATOMIC_INT_STORE(state->active, GLATTER_WSI_EGL_VALUE);
-        if (requested == GLATTER_WSI_AUTO_VALUE && !GLATTER_ATOMIC_INT_LOAD(state->wsi_explicit)) {
-            GLATTER_ATOMIC_INT_STORE(state->requested, GLATTER_WSI_EGL_VALUE);
-            GLATTER_ATOMIC_INT_STORE(state->wsi_explicit, 1);
+        if (requested == GLATTER_WSI_AUTO_VALUE) {
+            (void)glatter_select_wsi_once_(state, GLATTER_WSI_EGL_VALUE);
         }
         return ptr;
     }


### PR DESCRIPTION
## Summary
- add a helper that atomically latches the selected WSI from AUTO
- use the helper when resolving WGL/GLX/EGL so only one thread updates the requested WSI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da35fbc548832d8f30501ef1cce642