### PR TITLE
Share header-only loader state across translation units

### DIFF
--- a/include/glatter/glatter_solo.h
+++ b/include/glatter/glatter_solo.h
@@ -7,12 +7,10 @@
  * NOTE 1: Do not mix header-only and compiled-TU modes in the same binary.
  * If you compile glatter.c (compiled mode), do NOT include this header anywhere.
  *
- * NOTE 2: In header-only builds the tiny loader state lives per translation unit.
- * Detection is deterministic (e.g., WGL?EGL on Windows; GLX?EGL on POSIX), so
- * all TUs converge to the same WSI under the same build and environment.
- * You can still use the compiled C translation unit variant if you prefer having
- * one shared state for the entire process or slightly smaller binaries,
- * but not for correctness.
+ * NOTE 2: Header-only builds now share a single loader state via link-once
+ * storage so every translation unit observes the same WSI decision.
+ * You can still use the compiled C translation unit variant if you prefer
+ * slightly smaller binaries, but not for correctness.
  */
 
 #if !defined(__cplusplus)


### PR DESCRIPTION
## Summary
- use link-once storage for header-only loader globals so every TU shares one WSI decision
- update header-only documentation to reflect the shared process-wide state
- add a regression test to ensure header-only builds share WSI state across translation units

## Testing
- pytest tests/test_build.py::test_header_only_wsi_state_shared_across_tus -q

------
https://chatgpt.com/codex/tasks/task_b_68da3f67f5e0832db1d9be86e9f931d7