### PR TITLE
Use call_once wrappers for POSIX symbol resolution

### DIFF
--- a/include/glatter/gltr_once.h
+++ b/include/glatter/gltr_once.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifdef _WIN32
+  #include <windows.h>
+  typedef INIT_ONCE gltr_once_t;
+  #define GLTR_ONCE_INIT INIT_ONCE_STATIC_INIT
+  static BOOL CALLBACK gltr__once_adapter(PINIT_ONCE, PVOID param, PVOID*) {
+      ((void(*)(void))param)();
+      return TRUE;
+  }
+  static inline void gltr_call_once(gltr_once_t *o, void (*fn)(void)) {
+      InitOnceExecuteOnce(o, gltr__once_adapter, (PVOID)fn, NULL);
+  }
+#else
+  #include <pthread.h>
+  typedef pthread_once_t gltr_once_t;
+  #define GLTR_ONCE_INIT PTHREAD_ONCE_INIT
+  static inline void gltr_call_once(gltr_once_t *o, void (*fn)(void)) {
+      pthread_once(o, fn);
+  }
+#endif


### PR DESCRIPTION
## Summary
- add a tiny cross-platform gltr_call_once helper header
- use the helper to resolve POSIX function pointers via permanent thunks instead of pointer swaps
- include the new header and remove the ad-hoc pthread-based exchange helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da7e52d230832db2942e6aca278b5d