### PR TITLE
Share WSI decision gate across translation units

### DIFF
--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -3,5 +3,6 @@ Test Run Report
 
 | Date (UTC)         | Command | Result            |
 | ------------------ | ------- | ----------------- |
+| 2025-09-29 16:00:07 | pytest  | All tests passed. |
 | 2025-09-28 22:08:23 | pytest  | All tests passed. |
 | 2025-09-27 12:09:53 | pytest  | All tests passed. |


### PR DESCRIPTION
## Summary
- replace the per-translation-unit WSI gate with a function-local static accessor so all TUs share the same guard
- update glatter_get_proc_address to synchronize on the shared gate before running the one-time WSI selection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68daaa1d9320832d8dfe444e29c1fb83