### PR TITLE
Cache extension support per GL context

### DIFF
--- a/include/glatter/glatter.py
+++ b/include/glatter/glatter.py
@@ -1065,11 +1065,57 @@ def get_ext_support_def(v):
     rv = '''
 #include <string.h> /* memcpy */
 
+/* ---- Per-context, per-thread extension support cache (generated) ---- */
+#ifndef GLATTER_ES_CACHE_SLOTS
+#define GLATTER_ES_CACHE_SLOTS 8
+#endif
+
+typedef struct {
+    uintptr_t key; /* context key from glatter_current_gl_context_key_() */
+    glatter_extension_support_status_''' + v + '''_t ess;
+} glatter_es_cache_entry_''' + v + '''_t;
+
+static GLATTER_THREAD_LOCAL glatter_es_cache_entry_''' + v + '''_t
+    glatter_es_cache_''' + v + '''[GLATTER_ES_CACHE_SLOTS];
+
+static GLATTER_THREAD_LOCAL unsigned glatter_es_cache_pos_''' + v + ''' = 0;
+
+/* Optional: public invalidation for this family. */
+GLATTER_INLINE_OR_NOT void glatter_invalidate_extension_cache_''' + v + '''(void) {
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        glatter_es_cache_''' + v + '''[i].key = (uintptr_t)0;
+    }
+}
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_''' + v + '''()
 {
-    static int indexed_extensions[''' + str(len(ext_names_sorted[v])) + '''];
-    static glatter_extension_support_status_''' + v + '''_t ess;
+    /* Per-thread scratch array to build the bitset before mapping into ess. */
+    static GLATTER_THREAD_LOCAL int indexed_extensions[''' + str(len(ext_names_sorted[v])) + '''];
+
+    /* Local result object (returned by value). */
+    glatter_extension_support_status_''' + v + '''_t ess; /* will be filled then returned */
+    memset(&ess, 0, sizeof(ess));
+
+    /* 1) Compute a key for the current context; 0 means "no current context". */
+    uintptr_t ctx_key = glatter_current_gl_context_key_();
+
+    /* 2) If no current context, return zeros without touching the cache. */
+    if (ctx_key == (uintptr_t)0) {
+        /* Leave ess zero-initialized to indicate "no extensions known". */
+        return ess;
+    }
+
+    /* 3) Cache lookup (TLS ring of 8 entries). */
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        if (glatter_es_cache_''' + v + '''[i].key == ctx_key) {
+            return glatter_es_cache_''' + v + '''[i].ess; /* HIT */
+        }
+    }
+
+    /* 4) MISS: (re)build indexed_extensions[...] for the *current* context. */
+    /* Ensure scratch is cleared before probing. */
+    memset(indexed_extensions, 0, sizeof(indexed_extensions));
 
     typedef glatter_es_record_t rt;
 #ifdef __cplusplus
@@ -1094,8 +1140,6 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
     };
 
 
-    static int initialized = 0;
-    if (!initialized) {
 '''
     if (v == 'GL'):
         rv += '''
@@ -1105,8 +1149,6 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
         }
         int new_way = 0;
         if (!glv) {
-            initialized = 1;
-            memcpy((void*)&ess, indexed_extensions, sizeof(ess));
             return ess;
         }
         if (glv[0] < '0' || glv[0] > '9') {
@@ -1248,12 +1290,13 @@ glatter_extension_support_status_''' + v + '''_t glatter_get_extension_support_'
         '''
 
     rv += '''
-        initialized = 1;
-    }
-    
     // Map array to a struct without undefined behaviour.
     // No actual copy is performed with even basic optimization e.g.: -Og
-    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess));
+
+    glatter_es_cache_''' + v + '''[glatter_es_cache_pos_''' + v + '''].key = ctx_key;
+    glatter_es_cache_''' + v + '''[glatter_es_cache_pos_''' + v + '''].ess = ess;
+    glatter_es_cache_pos_''' + v + ''' = (glatter_es_cache_pos_''' + v + ''' + 1) % GLATTER_ES_CACHE_SLOTS;
 
     return ess;
 }

--- a/include/glatter/glatter_def.h
+++ b/include/glatter/glatter_def.h
@@ -1696,6 +1696,22 @@ void glatter_dbg_return(const char* fmt, ...)
 #endif
 #endif
 
+/* Unique-ish key for the *current* GL/WSI context, per platform. */
+GLATTER_INLINE_OR_NOT uintptr_t glatter_current_gl_context_key_(void) {
+#if defined(_WIN32)
+    /* WGL: combine context and DC. */
+    return (uintptr_t)wglGetCurrentContext() ^ (uintptr_t)wglGetCurrentDC();
+#elif defined(GLATTER_GLX)
+    /* GLX: combine context and Display*. */
+    return ((uintptr_t)glXGetCurrentContext() << 32) ^ (uintptr_t)glXGetCurrentDisplay();
+#elif defined(GLATTER_EGL)
+    /* EGL: combine context and Display*. */
+    return ((uintptr_t)eglGetCurrentContext() << 32) ^ (uintptr_t)eglGetCurrentDisplay();
+#else
+    return (uintptr_t)0; /* Unknown WSI -> treated as "no current context". */
+#endif
+}
+
 #if defined(GLATTER_GL)
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GL_ges_def.h)
 #endif
@@ -1708,6 +1724,22 @@ void glatter_dbg_return(const char* fmt, ...)
 #if defined(GLATTER_WGL)
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_WGL_ges_def.h)
 #endif
+
+/* Optional convenience to invalidate all families' caches available in this build. */
+GLATTER_INLINE_OR_NOT void glatter_invalidate_all_extension_caches(void) {
+#if defined(GLATTER_GL)
+    glatter_invalidate_extension_cache_GL();
+#endif
+#if defined(GLATTER_GLX)
+    glatter_invalidate_extension_cache_GLX();
+#endif
+#if defined(GLATTER_WGL)
+    glatter_invalidate_extension_cache_WGL();
+#endif
+#if defined(GLATTER_EGL) && GLATTER_HAS_EGL_GENERATED_HEADERS
+    glatter_invalidate_extension_cache_EGL();
+#endif
+}
 
 #if defined(GLATTER_GL)
     #include GLATTER_xstr(GLATTER_PDIR(GLATTER_PLATFORM_DIR)/glatter_GL_e2s_def.h)

--- a/include/glatter/platforms/glatter_mesa_egl_gles/glatter_EGL_ges_def.h
+++ b/include/glatter/platforms/glatter_mesa_egl_gles/glatter_EGL_ges_def.h
@@ -29,11 +29,57 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <string.h> /* memcpy */
 
+/* ---- Per-context, per-thread extension support cache (generated) ---- */
+#ifndef GLATTER_ES_CACHE_SLOTS
+#define GLATTER_ES_CACHE_SLOTS 8
+#endif
+
+typedef struct {
+    uintptr_t key; /* context key from glatter_current_gl_context_key_() */
+    glatter_extension_support_status_EGL_t ess;
+} glatter_es_cache_entry_EGL_t;
+
+static GLATTER_THREAD_LOCAL glatter_es_cache_entry_EGL_t
+    glatter_es_cache_EGL[GLATTER_ES_CACHE_SLOTS];
+
+static GLATTER_THREAD_LOCAL unsigned glatter_es_cache_pos_EGL = 0;
+
+/* Optional: public invalidation for this family. */
+GLATTER_INLINE_OR_NOT void glatter_invalidate_extension_cache_EGL(void) {
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        glatter_es_cache_EGL[i].key = (uintptr_t)0;
+    }
+}
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
 {
-    static int indexed_extensions[125];
-    static glatter_extension_support_status_EGL_t ess;
+    /* Per-thread scratch array to build the bitset before mapping into ess. */
+    static GLATTER_THREAD_LOCAL int indexed_extensions[125];
+
+    /* Local result object (returned by value). */
+    glatter_extension_support_status_EGL_t ess; /* will be filled then returned */
+    memset(&ess, 0, sizeof(ess));
+
+    /* 1) Compute a key for the current context; 0 means "no current context". */
+    uintptr_t ctx_key = glatter_current_gl_context_key_();
+
+    /* 2) If no current context, return zeros without touching the cache. */
+    if (ctx_key == (uintptr_t)0) {
+        /* Leave ess zero-initialized to indicate "no extensions known". */
+        return ess;
+    }
+
+    /* 3) Cache lookup (TLS ring of 8 entries). */
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        if (glatter_es_cache_EGL[i].key == ctx_key) {
+            return glatter_es_cache_EGL[i].ess; /* HIT */
+        }
+    }
+
+    /* 4) MISS: (re)build indexed_extensions[...] for the *current* context. */
+    /* Ensure scratch is cleared before probing. */
+    memset(indexed_extensions, 0, sizeof(indexed_extensions));
 
     typedef glatter_es_record_t rt;
 #ifdef __cplusplus
@@ -722,8 +768,6 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
     };
 
 
-    static int initialized = 0;
-    if (!initialized) {
 
         uint32_t hash = 5381;
         const uint8_t* ext_str = (const uint8_t*)glatter_eglQueryString(eglGetCurrentDisplay(), EGL_EXTENSIONS);
@@ -766,12 +810,13 @@ glatter_extension_support_status_EGL_t glatter_get_extension_support_EGL()
             }
         }
         
-        initialized = 1;
-    }
-    
     // Map array to a struct without undefined behaviour.
     // No actual copy is performed with even basic optimization e.g.: -Og
-    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess));
+
+    glatter_es_cache_EGL[glatter_es_cache_pos_EGL].key = ctx_key;
+    glatter_es_cache_EGL[glatter_es_cache_pos_EGL].ess = ess;
+    glatter_es_cache_pos_EGL = (glatter_es_cache_pos_EGL + 1) % GLATTER_ES_CACHE_SLOTS;
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GLX_ges_def.h
+++ b/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GLX_ges_def.h
@@ -29,11 +29,57 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <string.h> /* memcpy */
 
+/* ---- Per-context, per-thread extension support cache (generated) ---- */
+#ifndef GLATTER_ES_CACHE_SLOTS
+#define GLATTER_ES_CACHE_SLOTS 8
+#endif
+
+typedef struct {
+    uintptr_t key; /* context key from glatter_current_gl_context_key_() */
+    glatter_extension_support_status_GLX_t ess;
+} glatter_es_cache_entry_GLX_t;
+
+static GLATTER_THREAD_LOCAL glatter_es_cache_entry_GLX_t
+    glatter_es_cache_GLX[GLATTER_ES_CACHE_SLOTS];
+
+static GLATTER_THREAD_LOCAL unsigned glatter_es_cache_pos_GLX = 0;
+
+/* Optional: public invalidation for this family. */
+GLATTER_INLINE_OR_NOT void glatter_invalidate_extension_cache_GLX(void) {
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        glatter_es_cache_GLX[i].key = (uintptr_t)0;
+    }
+}
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
 {
-    static int indexed_extensions[70];
-    static glatter_extension_support_status_GLX_t ess;
+    /* Per-thread scratch array to build the bitset before mapping into ess. */
+    static GLATTER_THREAD_LOCAL int indexed_extensions[70];
+
+    /* Local result object (returned by value). */
+    glatter_extension_support_status_GLX_t ess; /* will be filled then returned */
+    memset(&ess, 0, sizeof(ess));
+
+    /* 1) Compute a key for the current context; 0 means "no current context". */
+    uintptr_t ctx_key = glatter_current_gl_context_key_();
+
+    /* 2) If no current context, return zeros without touching the cache. */
+    if (ctx_key == (uintptr_t)0) {
+        /* Leave ess zero-initialized to indicate "no extensions known". */
+        return ess;
+    }
+
+    /* 3) Cache lookup (TLS ring of 8 entries). */
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        if (glatter_es_cache_GLX[i].key == ctx_key) {
+            return glatter_es_cache_GLX[i].ess; /* HIT */
+        }
+    }
+
+    /* 4) MISS: (re)build indexed_extensions[...] for the *current* context. */
+    /* Ensure scratch is cleared before probing. */
+    memset(indexed_extensions, 0, sizeof(indexed_extensions));
 
     typedef glatter_es_record_t rt;
 #ifdef __cplusplus
@@ -667,8 +713,6 @@ glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
     };
 
 
-    static int initialized = 0;
-    if (!initialized) {
 
         uint32_t hash = 5381;
         Display* d = glXGetCurrentDisplay();
@@ -712,12 +756,13 @@ glatter_extension_support_status_GLX_t glatter_get_extension_support_GLX()
             }
         }
         
-        initialized = 1;
-    }
-    
     // Map array to a struct without undefined behaviour.
     // No actual copy is performed with even basic optimization e.g.: -Og
-    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess));
+
+    glatter_es_cache_GLX[glatter_es_cache_pos_GLX].key = ctx_key;
+    glatter_es_cache_GLX[glatter_es_cache_pos_GLX].ess = ess;
+    glatter_es_cache_pos_GLX = (glatter_es_cache_pos_GLX + 1) % GLATTER_ES_CACHE_SLOTS;
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_mesa_glx_gl/glatter_GL_ges_def.h
@@ -29,11 +29,57 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <string.h> /* memcpy */
 
+/* ---- Per-context, per-thread extension support cache (generated) ---- */
+#ifndef GLATTER_ES_CACHE_SLOTS
+#define GLATTER_ES_CACHE_SLOTS 8
+#endif
+
+typedef struct {
+    uintptr_t key; /* context key from glatter_current_gl_context_key_() */
+    glatter_extension_support_status_GL_t ess;
+} glatter_es_cache_entry_GL_t;
+
+static GLATTER_THREAD_LOCAL glatter_es_cache_entry_GL_t
+    glatter_es_cache_GL[GLATTER_ES_CACHE_SLOTS];
+
+static GLATTER_THREAD_LOCAL unsigned glatter_es_cache_pos_GL = 0;
+
+/* Optional: public invalidation for this family. */
+GLATTER_INLINE_OR_NOT void glatter_invalidate_extension_cache_GL(void) {
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        glatter_es_cache_GL[i].key = (uintptr_t)0;
+    }
+}
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 {
-    static int indexed_extensions[622];
-    static glatter_extension_support_status_GL_t ess;
+    /* Per-thread scratch array to build the bitset before mapping into ess. */
+    static GLATTER_THREAD_LOCAL int indexed_extensions[622];
+
+    /* Local result object (returned by value). */
+    glatter_extension_support_status_GL_t ess; /* will be filled then returned */
+    memset(&ess, 0, sizeof(ess));
+
+    /* 1) Compute a key for the current context; 0 means "no current context". */
+    uintptr_t ctx_key = glatter_current_gl_context_key_();
+
+    /* 2) If no current context, return zeros without touching the cache. */
+    if (ctx_key == (uintptr_t)0) {
+        /* Leave ess zero-initialized to indicate "no extensions known". */
+        return ess;
+    }
+
+    /* 3) Cache lookup (TLS ring of 8 entries). */
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        if (glatter_es_cache_GL[i].key == ctx_key) {
+            return glatter_es_cache_GL[i].ess; /* HIT */
+        }
+    }
+
+    /* 4) MISS: (re)build indexed_extensions[...] for the *current* context. */
+    /* Ensure scratch is cleared before probing. */
+    memset(indexed_extensions, 0, sizeof(indexed_extensions));
 
     typedef glatter_es_record_t rt;
 #ifdef __cplusplus
@@ -1206,8 +1252,6 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
     };
 
 
-    static int initialized = 0;
-    if (!initialized) {
 
         const uint8_t* glv = NULL;
         if (glatter_get_proc_address_GL("glGetString")) {
@@ -1215,8 +1259,6 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
         }
         int new_way = 0;
         if (!glv) {
-            initialized = 1;
-            memcpy((void*)&ess, indexed_extensions, sizeof(ess));
             return ess;
         }
         if (glv[0] < '0' || glv[0] > '9') {
@@ -1296,12 +1338,13 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
         }
 #endif
 
-        initialized = 1;
-    }
-    
     // Map array to a struct without undefined behaviour.
     // No actual copy is performed with even basic optimization e.g.: -Og
-    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess));
+
+    glatter_es_cache_GL[glatter_es_cache_pos_GL].key = ctx_key;
+    glatter_es_cache_GL[glatter_es_cache_pos_GL].ess = ess;
+    glatter_es_cache_pos_GL = (glatter_es_cache_pos_GL + 1) % GLATTER_ES_CACHE_SLOTS;
 
     return ess;
 }

--- a/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_def.h
+++ b/include/glatter/platforms/glatter_windows_wgl_gl/glatter_GL_ges_def.h
@@ -29,11 +29,57 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <string.h> /* memcpy */
 
+/* ---- Per-context, per-thread extension support cache (generated) ---- */
+#ifndef GLATTER_ES_CACHE_SLOTS
+#define GLATTER_ES_CACHE_SLOTS 8
+#endif
+
+typedef struct {
+    uintptr_t key; /* context key from glatter_current_gl_context_key_() */
+    glatter_extension_support_status_GL_t ess;
+} glatter_es_cache_entry_GL_t;
+
+static GLATTER_THREAD_LOCAL glatter_es_cache_entry_GL_t
+    glatter_es_cache_GL[GLATTER_ES_CACHE_SLOTS];
+
+static GLATTER_THREAD_LOCAL unsigned glatter_es_cache_pos_GL = 0;
+
+/* Optional: public invalidation for this family. */
+GLATTER_INLINE_OR_NOT void glatter_invalidate_extension_cache_GL(void) {
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        glatter_es_cache_GL[i].key = (uintptr_t)0;
+    }
+}
+
 GLATTER_INLINE_OR_NOT
 glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
 {
-    static int indexed_extensions[620];
-    static glatter_extension_support_status_GL_t ess;
+    /* Per-thread scratch array to build the bitset before mapping into ess. */
+    static GLATTER_THREAD_LOCAL int indexed_extensions[620];
+
+    /* Local result object (returned by value). */
+    glatter_extension_support_status_GL_t ess; /* will be filled then returned */
+    memset(&ess, 0, sizeof(ess));
+
+    /* 1) Compute a key for the current context; 0 means "no current context". */
+    uintptr_t ctx_key = glatter_current_gl_context_key_();
+
+    /* 2) If no current context, return zeros without touching the cache. */
+    if (ctx_key == (uintptr_t)0) {
+        /* Leave ess zero-initialized to indicate "no extensions known". */
+        return ess;
+    }
+
+    /* 3) Cache lookup (TLS ring of 8 entries). */
+    for (unsigned i = 0; i < GLATTER_ES_CACHE_SLOTS; ++i) {
+        if (glatter_es_cache_GL[i].key == ctx_key) {
+            return glatter_es_cache_GL[i].ess; /* HIT */
+        }
+    }
+
+    /* 4) MISS: (re)build indexed_extensions[...] for the *current* context. */
+    /* Ensure scratch is cleared before probing. */
+    memset(indexed_extensions, 0, sizeof(indexed_extensions));
 
     typedef glatter_es_record_t rt;
 #ifdef __cplusplus
@@ -1204,8 +1250,6 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
     };
 
 
-    static int initialized = 0;
-    if (!initialized) {
 
         const uint8_t* glv = NULL;
         if (glatter_get_proc_address_GL("glGetString")) {
@@ -1213,8 +1257,6 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
         }
         int new_way = 0;
         if (!glv) {
-            initialized = 1;
-            memcpy((void*)&ess, indexed_extensions, sizeof(ess));
             return ess;
         }
         if (glv[0] < '0' || glv[0] > '9') {
@@ -1294,12 +1336,13 @@ glatter_extension_support_status_GL_t glatter_get_extension_support_GL()
         }
 #endif
 
-        initialized = 1;
-    }
-    
     // Map array to a struct without undefined behaviour.
     // No actual copy is performed with even basic optimization e.g.: -Og
-    memcpy((void*)&ess, indexed_extensions, sizeof(ess)); 
+    memcpy((void*)&ess, indexed_extensions, sizeof(ess));
+
+    glatter_es_cache_GL[glatter_es_cache_pos_GL].key = ctx_key;
+    glatter_es_cache_GL[glatter_es_cache_pos_GL].ess = ess;
+    glatter_es_cache_pos_GL = (glatter_es_cache_pos_GL + 1) % GLATTER_ES_CACHE_SLOTS;
 
     return ess;
 }

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -79,6 +79,11 @@ def _write_egl_stub(directory: Path) -> Path:
             {
                 return EGL_NO_DISPLAY;
             }
+
+            EGLContext eglGetCurrentContext(void)
+            {
+                return EGL_NO_CONTEXT;
+            }
             """
         ).strip()
         + "\n"


### PR DESCRIPTION
## Summary
- derive a current-context key helper and invalidate-all convenience in `glatter_def.h`
- teach the extension support generator to use a TLS ring cache with per-context entries
- regenerate the family extension support sources to use the new cache and update the EGL test stub

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dabf96ae04832d9f4363cd2fa956ba