### PR TITLE
glatter: make context-key mixing portable (32/64-bit safe)

### DIFF
--- a/include/glatter/glatter_config_user.h
+++ b/include/glatter/glatter_config_user.h
@@ -25,4 +25,10 @@
 /* X11 */
 #define GLATTER_INSTALL_X_ERROR_HANDLER      1
 
+/* Optional: override the number of per-thread extension-cache slots.
+   Raise only if your app rapidly swaps among >8 contexts on the same thread. */
+#ifndef GLATTER_ES_CACHE_SLOTS
+#define GLATTER_ES_CACHE_SLOTS               8
+#endif
+
 #endif /* GLATTER_CONFIG_USER_H */


### PR DESCRIPTION
## Summary
- replace the GL context key helper with a portable rotation-based mixer that avoids out-of-range shifts and reports 0 when no context is bound
- document the helper's invariants for maintainers
- allow integrators to override the per-thread extension cache slot count via glatter_config_user.h

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68daca1a6a00832d9634920a20623e2a