### PR TITLE
tests: cover EGL context key mixer regression

### DIFF
--- a/include/glatter/glatter_config_user.h
+++ b/include/glatter/glatter_config_user.h
@@ -25,4 +25,10 @@
 /* X11 */
 #define GLATTER_INSTALL_X_ERROR_HANDLER      1
 
+/* Optional: override the number of per-thread extension-cache slots.
+   Raise only if your app rapidly swaps among >8 contexts on the same thread. */
+#ifndef GLATTER_ES_CACHE_SLOTS
+#define GLATTER_ES_CACHE_SLOTS               8
+#endif
+
 #endif /* GLATTER_CONFIG_USER_H */

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -466,6 +466,119 @@ def test_cpp_program_links_against_static_library(tmp_path: Path) -> None:
     )
 
 
+def test_context_key_mixer_behaves_with_stubbed_egl(tmp_path: Path) -> None:
+    """Exercise glatter_current_gl_context_key_() under controlled EGL stubs."""
+
+    cc = _require_tool("cc")
+
+    source = tmp_path / "context_key_test.c"
+    source.write_text(
+        textwrap.dedent(
+            """
+            #include <inttypes.h>
+            #include <stdint.h>
+            #include <stdio.h>
+            #include <EGL/egl.h>
+            #include <glatter/glatter.h>
+
+            #undef eglGetCurrentContext
+            #undef eglGetCurrentDisplay
+            #undef eglGetError
+            #undef glGetError
+
+            extern uintptr_t glatter_current_gl_context_key_(void);
+
+            static uintptr_t g_fake_context = (uintptr_t)0;
+            static uintptr_t g_fake_display = (uintptr_t)0;
+
+            EGLAPI EGLContext EGLAPIENTRY eglGetCurrentContext(void)
+            {
+                return (EGLContext)(uintptr_t)g_fake_context;
+            }
+
+            EGLAPI EGLDisplay EGLAPIENTRY eglGetCurrentDisplay(void)
+            {
+                return (EGLDisplay)(uintptr_t)g_fake_display;
+            }
+
+            EGLAPI EGLint EGLAPIENTRY eglGetError(void)
+            {
+                return EGL_SUCCESS;
+            }
+
+            unsigned int glGetError(void)
+            {
+                return 0u;
+            }
+
+            int main(void)
+            {
+                const uintptr_t ctx_value = (uintptr_t)0x13572468u;
+                const uintptr_t display_value = (uintptr_t)0xFDB97531u;
+
+                g_fake_context = (uintptr_t)0;
+                g_fake_display = (uintptr_t)0;
+
+                if (glatter_current_gl_context_key_() != (uintptr_t)0) {
+                    fprintf(stderr, "expected zero key when no context\\n");
+                    return 1;
+                }
+
+                g_fake_context = ctx_value;
+                g_fake_display = display_value;
+
+                const unsigned half = (unsigned)(sizeof(uintptr_t) * 4u);
+                const unsigned bits = (unsigned)(sizeof(uintptr_t) * 8u);
+                const uintptr_t expected_rotation =
+                    (uintptr_t)((display_value << half) | (display_value >> (bits - half)));
+                const uintptr_t expected = ctx_value ^ expected_rotation;
+
+                const uintptr_t observed = glatter_current_gl_context_key_();
+                if (observed != expected) {
+                    fprintf(
+                        stderr,
+                        "expected key %#" PRIxPTR " but got %#" PRIxPTR "\\n",
+                        expected,
+                        observed);
+                    return 2;
+                }
+
+                return 0;
+            }
+            """
+        ).strip()
+        + "\n"
+    )
+
+    config_flags = [
+        "-DGLATTER_CONFIG_H_DEFINED",
+        "-DGLATTER_GL=0",
+        "-DGLATTER_EGL=1",
+        "-DGLATTER_EGL_GLES2_2_0=1",
+    ]
+
+    output = tmp_path / "context_key_test"
+    _run_command(
+        [
+            cc,
+            "-std=c11",
+            *config_flags,
+            "-I",
+            str(REPO_ROOT / "include"),
+            "-I",
+            str(REPO_ROOT / "tests" / "include"),
+            "-pthread",
+            str(REPO_ROOT / "src" / "glatter" / "glatter.c"),
+            str(source),
+            "-ldl",
+            "-o",
+            str(output),
+        ]
+    )
+
+    _run_command([output])
+
+
 def test_wgl_headers_compile_with_stubs(tmp_path: Path) -> None:
     """Verify WGL-enabled builds compile when using stubbed Windows headers."""
 


### PR DESCRIPTION
## Summary
- add a regression test that exercises glatter_current_gl_context_key_ using stubbed EGL handles to validate zero/no-context handling and the mixer output

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68daca1a6a00832d9634920a20623e2a