### PR TITLE
Add CMake-based smoke tests for glatter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+project(glatter LANGUAGES C CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+
+add_subdirectory(tests/cmake)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ glClear(GL_COLOR_BUFFER_BIT);
 3. Link platform libraries (see Integration notes).
 4. Optional: install a custom log sink only if you want to redirect messages away from stdout/stderr.
 
+### CMake smoke tests for CI/CD
+
+A companion CMake configuration replicates the build smoke-tests previously implemented in `tests/test_build.py`. It compiles representative consumers for both the compiled C translation unit and the header-only C++ modes, checks the static-library workflow, and exercises the internal EGL context-key helper using stubbed entry points.
+
+```bash
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build
+```
+
+The default build also verifies that the WGL headers continue to compile when paired with the lightweight Windows stubs in `tests/include/`. These targets have no runtime dependencies and are meant purely as CI/CD guardrails.
+
 ---
 
 ## Window System Interface (WSI) selection (auto and overrides)

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -1,0 +1,110 @@
+set(GLATTER_TEST_ROOT "${PROJECT_SOURCE_DIR}")
+set(GLATTER_TEST_INCLUDES
+    "${GLATTER_TEST_ROOT}/include"
+    "${GLATTER_TEST_ROOT}/tests/include"
+)
+
+find_package(Threads REQUIRED)
+
+add_library(glatter_egl_stubs STATIC egl_stubs.c)
+target_include_directories(glatter_egl_stubs PUBLIC ${GLATTER_TEST_INCLUDES})
+
+add_executable(glatter_c_smoketest c_program.c "${GLATTER_TEST_ROOT}/src/glatter/glatter.c")
+target_include_directories(glatter_c_smoketest PRIVATE ${GLATTER_TEST_INCLUDES})
+target_compile_definitions(glatter_c_smoketest PRIVATE
+    GLATTER_CONFIG_H_DEFINED
+    GLATTER_EGL_GLES2_2_0
+    GLATTER_EGL
+)
+target_link_libraries(glatter_c_smoketest PRIVATE
+    glatter_egl_stubs
+    Threads::Threads
+    ${CMAKE_DL_LIBS}
+)
+add_test(NAME glatter.c_smoketest COMMAND glatter_c_smoketest)
+
+add_executable(glatter_header_only
+    header_only_main.cpp
+    header_only_helper.cpp
+)
+target_include_directories(glatter_header_only PRIVATE ${GLATTER_TEST_INCLUDES})
+target_compile_definitions(glatter_header_only PRIVATE
+    GLATTER_CONFIG_H_DEFINED
+    GLATTER_HEADER_ONLY
+    GLATTER_EGL_GLES2_2_0
+    GLATTER_EGL
+)
+target_link_libraries(glatter_header_only PRIVATE
+    glatter_egl_stubs
+    Threads::Threads
+    ${CMAKE_DL_LIBS}
+)
+add_test(NAME glatter.header_only COMMAND glatter_header_only)
+
+add_executable(glatter_header_only_solo
+    header_only_solo_main.cpp
+    header_only_solo_helper.cpp
+)
+target_include_directories(glatter_header_only_solo PRIVATE ${GLATTER_TEST_INCLUDES})
+target_link_libraries(glatter_header_only_solo PRIVATE
+    Threads::Threads
+    ${CMAKE_DL_LIBS}
+)
+add_test(NAME glatter.header_only_solo COMMAND glatter_header_only_solo)
+
+add_library(glatter_test_static STATIC "${GLATTER_TEST_ROOT}/src/glatter/glatter.c")
+target_include_directories(glatter_test_static PUBLIC ${GLATTER_TEST_INCLUDES})
+target_compile_definitions(glatter_test_static PUBLIC
+    GLATTER_CONFIG_H_DEFINED
+    GLATTER_EGL_GLES2_2_0
+    GLATTER_EGL
+)
+target_link_libraries(glatter_test_static PUBLIC
+    Threads::Threads
+    ${CMAKE_DL_LIBS}
+)
+
+add_executable(glatter_static_link
+    static_link_main.cpp
+    static_link_helper.cpp
+)
+target_include_directories(glatter_static_link PRIVATE ${GLATTER_TEST_INCLUDES})
+target_compile_definitions(glatter_static_link PRIVATE
+    GLATTER_CONFIG_H_DEFINED
+    GLATTER_EGL_GLES2_2_0
+    GLATTER_EGL
+)
+target_link_libraries(glatter_static_link PRIVATE
+    glatter_test_static
+    glatter_egl_stubs
+)
+add_test(NAME glatter.static_link COMMAND glatter_static_link)
+
+add_executable(glatter_context_key
+    context_key_test.c
+    "${GLATTER_TEST_ROOT}/src/glatter/glatter.c"
+)
+target_include_directories(glatter_context_key PRIVATE ${GLATTER_TEST_INCLUDES})
+target_compile_definitions(glatter_context_key PRIVATE
+    GLATTER_CONFIG_H_DEFINED
+    GLATTER_GL=0
+    GLATTER_EGL=1
+    GLATTER_EGL_GLES2_2_0=1
+)
+target_link_libraries(glatter_context_key PRIVATE
+    Threads::Threads
+    ${CMAKE_DL_LIBS}
+)
+add_test(NAME glatter.context_key COMMAND glatter_context_key)
+
+add_library(glatter_wgl_headers OBJECT wgl_headers.c)
+target_include_directories(glatter_wgl_headers PRIVATE ${GLATTER_TEST_INCLUDES})
+target_compile_definitions(glatter_wgl_headers PRIVATE
+    _WIN32
+    GLATTER_CONFIG_H_DEFINED
+    GLATTER_GL=1
+    GLATTER_WGL=1
+    GLATTER_WINDOWS_WGL_GL=1
+    __STDC_NO_ATOMICS__=1
+)
+add_custom_target(glatter.build_wgl_headers ALL DEPENDS glatter_wgl_headers)

--- a/tests/cmake/c_program.c
+++ b/tests/cmake/c_program.c
@@ -1,0 +1,13 @@
+#include <glatter/glatter.h>
+
+static void noop_logger(const char* message)
+{
+    (void)message;
+}
+
+int main(void)
+{
+    glatter_set_log_handler(noop_logger);
+    glatter_set_log_handler(NULL);
+    return 0;
+}

--- a/tests/cmake/context_key_test.c
+++ b/tests/cmake/context_key_test.c
@@ -1,0 +1,71 @@
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <EGL/egl.h>
+#include <glatter/glatter.h>
+
+#undef eglGetCurrentContext
+#undef eglGetCurrentDisplay
+#undef eglGetError
+#undef glGetError
+
+extern uintptr_t glatter_current_gl_context_key_(void);
+
+static uintptr_t g_fake_context = (uintptr_t)0;
+static uintptr_t g_fake_display = (uintptr_t)0;
+
+EGLAPI EGLContext EGLAPIENTRY eglGetCurrentContext(void)
+{
+    return (EGLContext)(uintptr_t)g_fake_context;
+}
+
+EGLAPI EGLDisplay EGLAPIENTRY eglGetCurrentDisplay(void)
+{
+    return (EGLDisplay)(uintptr_t)g_fake_display;
+}
+
+EGLAPI EGLint EGLAPIENTRY eglGetError(void)
+{
+    return EGL_SUCCESS;
+}
+
+unsigned int glGetError(void)
+{
+    return 0u;
+}
+
+int main(void)
+{
+    const uintptr_t ctx_value = (uintptr_t)0x13572468u;
+    const uintptr_t display_value = (uintptr_t)0xFDB97531u;
+
+    g_fake_context = (uintptr_t)0;
+    g_fake_display = (uintptr_t)0;
+
+    if (glatter_current_gl_context_key_() != (uintptr_t)0) {
+        fprintf(stderr, "expected zero key when no context\n");
+        return 1;
+    }
+
+    g_fake_context = ctx_value;
+    g_fake_display = display_value;
+
+    const unsigned half = (unsigned)(sizeof(uintptr_t) * 4u);
+    const unsigned bits = (unsigned)(sizeof(uintptr_t) * 8u);
+    const uintptr_t expected_rotation =
+        (uintptr_t)((display_value << half) | (display_value >> (bits - half)));
+    const uintptr_t expected = ctx_value ^ expected_rotation;
+
+    const uintptr_t observed = glatter_current_gl_context_key_();
+    if (observed != expected) {
+        fprintf(
+            stderr,
+            "expected key %#" PRIxPTR " but got %#" PRIxPTR "\n",
+            expected,
+            observed);
+        return 2;
+    }
+
+    return 0;
+}

--- a/tests/cmake/egl_stubs.c
+++ b/tests/cmake/egl_stubs.c
@@ -1,0 +1,22 @@
+#include <EGL/egl.h>
+
+__eglMustCastToProperFunctionPointerType eglGetProcAddress(const char* name)
+{
+    (void)name;
+    return NULL;
+}
+
+EGLint eglGetError(void)
+{
+    return EGL_SUCCESS;
+}
+
+EGLDisplay eglGetCurrentDisplay(void)
+{
+    return EGL_NO_DISPLAY;
+}
+
+EGLContext eglGetCurrentContext(void)
+{
+    return EGL_NO_CONTEXT;
+}

--- a/tests/cmake/header_only_helper.cpp
+++ b/tests/cmake/header_only_helper.cpp
@@ -1,0 +1,6 @@
+#include <glatter/glatter.h>
+
+int helper()
+{
+    return glatter_get_proc_address("glGetString") != nullptr;
+}

--- a/tests/cmake/header_only_main.cpp
+++ b/tests/cmake/header_only_main.cpp
@@ -1,0 +1,11 @@
+#include <glatter/glatter.h>
+
+int helper();
+
+static void noop_logger(const char*) {}
+
+int main()
+{
+    glatter_set_log_handler(noop_logger);
+    return helper();
+}

--- a/tests/cmake/header_only_solo_helper.cpp
+++ b/tests/cmake/header_only_solo_helper.cpp
@@ -1,0 +1,6 @@
+#include <glatter/glatter_solo.h>
+
+int helper()
+{
+    return glatter_get_proc_address("glGetString") != nullptr;
+}

--- a/tests/cmake/header_only_solo_main.cpp
+++ b/tests/cmake/header_only_solo_main.cpp
@@ -1,0 +1,12 @@
+#include <glatter/glatter_solo.h>
+
+int helper();
+
+static void noop_logger(const char*) {}
+
+int main()
+{
+    glatter_set_log_handler(noop_logger);
+    glatter_set_log_handler(nullptr);
+    return helper();
+}

--- a/tests/cmake/static_link_helper.cpp
+++ b/tests/cmake/static_link_helper.cpp
@@ -1,0 +1,6 @@
+#include <glatter/glatter.h>
+
+int helper()
+{
+    return glatter_get_proc_address("glGetString") != nullptr;
+}

--- a/tests/cmake/static_link_main.cpp
+++ b/tests/cmake/static_link_main.cpp
@@ -1,0 +1,9 @@
+#include <glatter/glatter.h>
+
+int helper();
+
+int main()
+{
+    (void)glatter_get_wsi();
+    return helper();
+}

--- a/tests/cmake/wgl_headers.c
+++ b/tests/cmake/wgl_headers.c
@@ -1,0 +1,15 @@
+#include <stddef.h>
+
+#include <glatter/glatter.h>
+
+static void noop(const char* message)
+{
+    (void)message;
+}
+
+int main(void)
+{
+    glatter_set_log_handler(noop);
+    glatter_set_log_handler(NULL);
+    return glatter_get_wsi();
+}


### PR DESCRIPTION
## Summary
- add a top-level CMake configuration so the smoke tests can be driven by CI/CD
- port the Python build checks into reusable C/C++ sources and CMake targets, including stubbed EGL/WGL helpers
- document how to configure, build, and run the new CMake smoke tests

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_b_68dadeb4e5a4832dbc6453975985130d